### PR TITLE
Rename non-global variables loggingClient to lc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,19 @@
+# This gitignore was copied from https://github.com/github/gitignore/blob/master/Go.gitignore
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# GoLand/Jetbrains IDE
+/.idea
+
 go.sum

--- a/bootstrap/configuration/registry.go
+++ b/bootstrap/configuration/registry.go
@@ -60,7 +60,7 @@ func UpdateFromRegistry(
 	ctx context.Context,
 	startupTimer startup.Timer,
 	config interfaces.Configuration,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	serviceKey string) (registry.Client, error) {
 
 	var updateFromRegistry = func(registryClient registry.Client) error {
@@ -91,7 +91,7 @@ func UpdateFromRegistry(
 
 	for startupTimer.HasNotElapsed() {
 		if err := updateFromRegistry(registryClient); err != nil {
-			loggingClient.Warn(err.Error())
+			lc.Warn(err.Error())
 			select {
 			case <-ctx.Done():
 				return nil, errors.New("aborted UpdateFromRegistry()")
@@ -113,7 +113,7 @@ func ListenForChanges(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	config interfaces.Configuration,
-	loggingClient logger.LoggingClient,
+	lc logger.LoggingClient,
 	registryClient registry.Client) {
 
 	wg.Add(1)
@@ -134,7 +134,7 @@ func ListenForChanges(
 				return
 
 			case ex := <-errorStream:
-				loggingClient.Error(ex.Error())
+				lc.Error(ex.Error())
 
 			case raw, ok := <-updateStream:
 				if !ok {
@@ -142,12 +142,12 @@ func ListenForChanges(
 				}
 
 				if !config.UpdateWritableFromRaw(raw) {
-					loggingClient.Error("ListenForChanges() type check failed")
+					lc.Error("ListenForChanges() type check failed")
 					return
 				}
 
-				loggingClient.Info("Writeable configuration has been updated from the Registry")
-				loggingClient.SetLogLevel(config.GetLogLevel())
+				lc.Info("Writeable configuration has been updated from the Registry")
+				lc.SetLogLevel(config.GetLogLevel())
 			}
 		}
 	}()

--- a/bootstrap/handlers/httpserver/httpserver.go
+++ b/bootstrap/handlers/httpserver/httpserver.go
@@ -68,8 +68,8 @@ func (b *HttpServer) BootstrapHandler(
 		ReadTimeout:  timeout,
 	}
 
-	loggingClient := container.LoggingClientFrom(dic.Get)
-	loggingClient.Info("Web server starting (" + addr + ")")
+	lc := container.LoggingClientFrom(dic.Get)
+	lc.Info("Web server starting (" + addr + ")")
 
 	wg.Add(1)
 	go func() {
@@ -77,7 +77,7 @@ func (b *HttpServer) BootstrapHandler(
 
 		b.isRunning = true
 		server.ListenAndServe()
-		loggingClient.Info("Web server stopped")
+		lc.Info("Web server stopped")
 		b.isRunning = false
 	}()
 
@@ -86,9 +86,9 @@ func (b *HttpServer) BootstrapHandler(
 		defer wg.Done()
 
 		<-ctx.Done()
-		loggingClient.Info("Web server shutting down")
+		lc.Info("Web server shutting down")
 		server.Shutdown(context.Background())
-		loggingClient.Info("Web server shut down")
+		lc.Info("Web server shut down")
 	}()
 
 	return true

--- a/bootstrap/handlers/message/message.go
+++ b/bootstrap/handlers/message/message.go
@@ -46,16 +46,16 @@ func (h StartMessage) BootstrapHandler(
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 
-	loggingClient := container.LoggingClientFrom(dic.Get)
-	loggingClient.Info("Service dependencies resolved...")
-	loggingClient.Info(fmt.Sprintf("Starting %s %s ", h.serviceKey, h.version))
+	lc := container.LoggingClientFrom(dic.Get)
+	lc.Info("Service dependencies resolved...")
+	lc.Info(fmt.Sprintf("Starting %s %s ", h.serviceKey, h.version))
 
 	bootstrapConfig := container.ConfigurationFrom(dic.Get).GetBootstrap()
 	if len(bootstrapConfig.Service.StartupMsg) > 0 {
-		loggingClient.Info(bootstrapConfig.Service.StartupMsg)
+		lc.Info(bootstrapConfig.Service.StartupMsg)
 	}
 
-	loggingClient.Info("Service started in: " + startupTimer.SinceAsString())
+	lc.Info("Service started in: " + startupTimer.SinceAsString())
 
 	return true
 }

--- a/bootstrap/handlers/secret/secret.go
+++ b/bootstrap/handlers/secret/secret.go
@@ -50,12 +50,12 @@ func (s *SecretProvider) BootstrapHandler(
 	startupTimer startup.Timer,
 	dic *di.Container) bool {
 
-	loggingClient := container.LoggingClientFrom(dic.Get)
+	lc := container.LoggingClientFrom(dic.Get)
 
 	configuration := container.ConfigurationFrom(dic.Get)
 	secretConfig, err := s.getSecretConfig(configuration.GetBootstrap().SecretStore)
 	if err != nil {
-		loggingClient.Error(fmt.Sprintf("unable to parse secret store configuration: %s", err.Error()))
+		lc.Error(fmt.Sprintf("unable to parse secret store configuration: %s", err.Error()))
 		return false
 	}
 
@@ -63,7 +63,7 @@ func (s *SecretProvider) BootstrapHandler(
 	if s.isSecurityEnabled() {
 		s.secretClient, err = vault.NewSecretClient(secretConfig)
 		if err != nil {
-			loggingClient.Error(fmt.Sprintf("unable to create SecretClient: %s", err.Error()))
+			lc.Error(fmt.Sprintf("unable to create SecretClient: %s", err.Error()))
 			return false
 		}
 	}


### PR DESCRIPTION
Fix #16

Rename all non-global variable names from 'loggingClient' to 'lc'.

Update .gitignore to exclude common Go and IDE files.

Signed-off-by: Anthony M. Bonafide <AnthonyMBonafide@gmail.com>