### PR TITLE
Update to latest (v0.0.13) go-mod-secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,8 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.34
 	github.com/edgexfoundry/go-mod-registry v0.1.12
-	github.com/edgexfoundry/go-mod-secrets v0.0.9
-	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
-	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/edgexfoundry/go-mod-secrets v0.0.13
 	github.com/gorilla/mux v1.7.1
-	github.com/imdario/mergo v0.3.6
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )


### PR DESCRIPTION
Fixes: https://github.com/edgexfoundry/go-mod-bootstrap/issues/31
Signed-off-by: Michael W. Estrin <me@michaelestrin.com>