### PR TITLE
Add RunAndReturnWaitGroup() to bootstrap.go

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -81,7 +81,7 @@ func RunAndReturnWaitGroup(
 	serviceConfig interfaces.Configuration,
 	startupTimer startup.Timer,
 	dic *di.Container,
-	handlers []interfaces.BootstrapHandler) *sync.WaitGroup {
+	handlers []interfaces.BootstrapHandler) (*sync.WaitGroup, bool) {
 
 	lc := logging.FactoryToStdout(serviceKey)
 	var err error
@@ -169,14 +169,16 @@ func RunAndReturnWaitGroup(
 	})
 
 	// call individual bootstrap handlers.
+	startedSuccessfully := true
 	for i := range handlers {
 		if handlers[i](ctx, &wg, startupTimer, dic) == false {
 			cancel()
+			startedSuccessfully = false
 			break
 		}
 	}
 
-	return &wg
+	return &wg, startedSuccessfully
 }
 
 // Run bootstraps an application.  It loads configuration and calls the provided list of handlers.  Any long-running
@@ -194,7 +196,7 @@ func Run(
 	dic *di.Container,
 	handlers []interfaces.BootstrapHandler) {
 
-	wg := RunAndReturnWaitGroup(
+	wg, _ := RunAndReturnWaitGroup(
 		ctx,
 		cancel,
 		commonFlags,

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -66,11 +66,13 @@ func translateInterruptToCancel(ctx context.Context, wg *sync.WaitGroup, cancel 
 	}()
 }
 
-// Run bootstraps an application.  It loads configuration and calls the provided list of handlers.  Any long-running
-// process should be spawned as a go routine in a handler.  Handlers are expected to return immediately.  Once all of
-// the handlers are called this function will wait for any go routines spawned inside the handlers to exit before
-// returning to the caller.  It is intended that the caller stop executing on the return of this function.
-func Run(
+// RunAndReturnWaitGroup bootstraps an application.  It loads configuration and calls the provided list of handlers.
+// Any long-running process should be spawned as a go routine in a handler.  Handlers are expected to return
+// immediately.  Once all of the handlers are called this function will return a sync.WaitGroup reference to the caller.
+// It is intended that the caller take whatever additional action makes sense before calling Wait() on the returned
+// reference to wait for the application to be signaled to stop (and the corresponding goroutines spawned in the
+// various handlers to be stopped cleanly).
+func RunAndReturnWaitGroup(
 	ctx context.Context,
 	cancel context.CancelFunc,
 	commonFlags commandline.CommonFlags,
@@ -79,7 +81,7 @@ func Run(
 	serviceConfig interfaces.Configuration,
 	startupTimer startup.Timer,
 	dic *di.Container,
-	handlers []interfaces.BootstrapHandler) {
+	handlers []interfaces.BootstrapHandler) *sync.WaitGroup {
 
 	lc := logging.FactoryToStdout(serviceKey)
 	var err error
@@ -103,11 +105,18 @@ func Run(
 	//	Update the startup timer to reflect whatever configuration read, if anything available.
 	startupTimer.UpdateTimer(startupInfo.Duration, startupInfo.Interval)
 
-	// set up configClient and loggingClient; update configuration from configuration provider if we're using a provider.
 	switch configProviderInfo.UseProvider() {
 	case true:
-		configClient, err = config.UpdateFromProvider(ctx, startupTimer, configProviderInfo.ServiceConfig(),
-			serviceConfig, configStem, lc, serviceKey)
+		// set up configClient; use it to load configuration from provider.
+		configClient, err = config.UpdateFromProvider(
+			ctx,
+			startupTimer,
+			configProviderInfo.ServiceConfig(),
+			serviceConfig,
+			configStem,
+			lc,
+			serviceKey,
+		)
 		if err != nil {
 			fatalError(err, lc)
 		}
@@ -117,7 +126,14 @@ func Run(
 
 	case false:
 		// load configuration from file.
-		if err = config.LoadFromFile(lc, commonFlags.ConfigDirectory(), commonFlags.Profile(), configFileName, serviceConfig); err != nil {
+		err = config.LoadFromFile(
+			lc,
+			commonFlags.ConfigDirectory(),
+			commonFlags.Profile(),
+			configFileName,
+			serviceConfig,
+		)
+		if err != nil {
 			fatalError(err, lc)
 		}
 		lc = logging.FactoryFromConfiguration(serviceKey, serviceConfig)
@@ -159,6 +175,36 @@ func Run(
 			break
 		}
 	}
+
+	return &wg
+}
+
+// Run bootstraps an application.  It loads configuration and calls the provided list of handlers.  Any long-running
+// process should be spawned as a go routine in a handler.  Handlers are expected to return immediately.  Once all of
+// the handlers are called this function will wait for any go routines spawned inside the handlers to exit before
+// returning to the caller.  It is intended that the caller stop executing on the return of this function.
+func Run(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	commonFlags commandline.CommonFlags,
+	serviceKey string,
+	configStem string,
+	serviceConfig interfaces.Configuration,
+	startupTimer startup.Timer,
+	dic *di.Container,
+	handlers []interfaces.BootstrapHandler) {
+
+	wg := RunAndReturnWaitGroup(
+		ctx,
+		cancel,
+		commonFlags,
+		serviceKey,
+		configStem,
+		serviceConfig,
+		startupTimer,
+		dic,
+		handlers,
+	)
 
 	// wait for go routines to stop executing.
 	wg.Wait()

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.34
 	github.com/edgexfoundry/go-mod-registry v0.1.17
 	github.com/edgexfoundry/go-mod-secrets v0.0.14
-	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.1
 	github.com/stretchr/testify v1.3.0
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
 go 1.12


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: https://github.com/edgexfoundry/go-mod-bootstrap/issues/41


## What is the new behavior?

Adds new RunAndReturnWaitGroup() function.  Returns immediately instead of waiting on a sync.WaitGroup for the service to end.  New method intended to facilitate adoption of go-mod-bootstrap by AppFunc (and possibly device service) subdomain.

Existing Run() method kept intact for backward-compatible usage by core-services, support-services, and system management agent.

Minor code reformatting.  Minor comment updates.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information