### PR TITLE
Update the secret's BootstrapHandler to use the latest NewSecretClient

### DIFF
--- a/bootstrap/handlers/secret/client/mockserver_test.go
+++ b/bootstrap/handlers/secret/client/mockserver_test.go
@@ -1,0 +1,81 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
+)
+
+// getMockTokenServer is a test helper for unit tests of vaultclient
+func getMockTokenServer(tokenDataMap *sync.Map) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		urlPath := req.URL.String()
+		if req.Method == http.MethodGet && urlPath == "/v1/auth/token/lookup-self" {
+			token := req.Header.Get(vault.AuthTypeHeader)
+			sampleTokenLookup, exists := tokenDataMap.Load(token)
+			if !exists {
+				rw.WriteHeader(403)
+				_, _ = rw.Write([]byte("permission denied"))
+			} else {
+				resp := &vault.TokenLookupResponse{
+					Data: sampleTokenLookup.(vault.TokenLookupMetadata),
+				}
+				if ret, err := json.Marshal(resp); err != nil {
+					rw.WriteHeader(500)
+					_, _ = rw.Write([]byte(err.Error()))
+				} else {
+					rw.WriteHeader(200)
+					_, _ = rw.Write(ret)
+				}
+			}
+		} else if req.Method == http.MethodPost && urlPath == "/v1/auth/token/renew-self" {
+			token := req.Header.Get(vault.AuthTypeHeader)
+			sampleTokenLookup, exists := tokenDataMap.Load(token)
+			if !exists {
+				rw.WriteHeader(403)
+				_, _ = rw.Write([]byte("permission denied"))
+			} else {
+				currentTTL := sampleTokenLookup.(vault.TokenLookupMetadata).Ttl
+				if currentTTL <= 0 {
+					// already expired
+					rw.WriteHeader(403)
+					_, _ = rw.Write([]byte("permission denied"))
+				} else {
+					tokenPeriod := sampleTokenLookup.(vault.TokenLookupMetadata).Period
+
+					tokenDataMap.Store(token, vault.TokenLookupMetadata{
+						Renewable: true,
+						Ttl:       tokenPeriod,
+						Period:    tokenPeriod,
+					})
+					rw.WriteHeader(200)
+					_, _ = rw.Write([]byte("token renewed"))
+				}
+			}
+		} else {
+			rw.WriteHeader(404)
+			_, _ = rw.Write([]byte(fmt.Sprintf("Unknown urlPath: %s", urlPath)))
+		}
+	}))
+	return server
+}

--- a/bootstrap/handlers/secret/client/testdata/replacement.json
+++ b/bootstrap/handlers/secret/client/testdata/replacement.json
@@ -1,0 +1,9 @@
+{
+    "keys": [
+      "test-keys"
+    ],
+    "keys_base64": [
+      "test-keys-base64"
+    ],
+    "root_token": "replacement-token"
+}

--- a/bootstrap/handlers/secret/client/testdata/testToken.json
+++ b/bootstrap/handlers/secret/client/testdata/testToken.json
@@ -1,0 +1,9 @@
+{
+    "keys": [
+      "test-keys"
+    ],
+    "keys_base64": [
+      "test-keys-base64"
+    ],
+    "root_token": "test-token"
+}

--- a/bootstrap/handlers/secret/client/vaultclient.go
+++ b/bootstrap/handlers/secret/client/vaultclient.go
@@ -1,0 +1,91 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
+)
+
+type SecretVaultClient struct {
+	ctx    *context.Context
+	config *vault.SecretConfig
+	dic    *di.Container
+}
+
+func NewSecretVaultClient(
+	ctx context.Context,
+	config vault.SecretConfig,
+	dic *di.Container) SecretVaultClient {
+	return SecretVaultClient{
+		ctx:    &ctx,
+		config: &config,
+		dic:    dic,
+	}
+}
+
+func (c SecretVaultClient) GetClient() (pkg.SecretClient, error) {
+
+	lc := container.LoggingClientFrom(c.dic.Get)
+	configuration := container.ConfigurationFrom(c.dic.Get)
+	secretStoreInfo := configuration.GetBootstrap().SecretStore
+
+	return vault.NewSecretClientFactory().NewSecretClient(
+		*c.ctx,
+		*c.config,
+		lc,
+		c.getDefaultTokenExpiredCallback(secretStoreInfo))
+}
+
+func (c SecretVaultClient) getDefaultTokenExpiredCallback(
+	secretStoreInfo config.SecretStoreInfo) func(expiredToken string) (replacementToken string, retry bool) {
+	// if there is no tokenFile, then no replacement token can be used and hence no callback
+	if secretStoreInfo.TokenFile == "" {
+		return nil
+	}
+
+	lc := container.LoggingClientFrom(c.dic.Get)
+	tokenFile := secretStoreInfo.TokenFile
+	return func(expiredToken string) (replacementToken string, retry bool) {
+		// during the callback, we want to re-read the token from the disk
+		// specified by tokenFile and set the retry to true if a new token
+		// is different from the expiredToken
+		fileIoPerformer := fileioperformer.NewDefaultFileIoPerformer()
+		authTokenLoader := authtokenloader.NewAuthTokenLoader(fileIoPerformer)
+		reReadToken, err := authTokenLoader.Load(tokenFile)
+		if err != nil {
+			lc.Error(fmt.Sprintf("fail to load auth token from tokenFile %s: %v", tokenFile, err))
+			return "", false
+		}
+
+		if reReadToken == expiredToken {
+			lc.Error("No new replacement token found for the expired token")
+			return reReadToken, false
+		}
+
+		return reReadToken, true
+	}
+}

--- a/bootstrap/handlers/secret/client/vaultclient_test.go
+++ b/bootstrap/handlers/secret/client/vaultclient_test.go
@@ -18,71 +18,199 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/logging"
 	"github.com/edgexfoundry/go-mod-bootstrap/config"
-	"github.com/edgexfoundry/go-mod-bootstrap/di"
 
 	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
 )
 
-type configurationStruct struct {
-	writable    writableInfo
-	logging     config.LoggingInfo
-	secretStore config.SecretStoreInfo
-}
-
-type writableInfo struct {
-	logLevel string
-}
-
-func (c *configurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
-	return true
-}
-
-func (c *configurationStruct) EmptyWritablePtr() interface{} {
-	return &writableInfo{}
-}
-
-func (c *configurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
-	return true
-}
-
-func (c *configurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
-	// temporary until we can make backwards-breaking configuration.toml change
-	return interfaces.BootstrapConfiguration{
-		Logging:     c.logging,
-		SecretStore: c.secretStore,
-	}
-}
-
-func (c *configurationStruct) GetLogLevel() string {
-	return c.writable.logLevel
-}
-
-func (c *configurationStruct) GetRegistryInfo() config.RegistryInfo {
-	return config.RegistryInfo{}
-}
-
-func TestGetClient(t *testing.T) {
-	// run in parallel with other tests
-	t.Parallel()
-
+func TestGetVaultClient(t *testing.T) {
 	// setup
 	tokenPeriod := 6
+	tokenDataMap := initTokenData(tokenPeriod)
+	server := getMockTokenServer(tokenDataMap)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Errorf("error on parsing server url %s: %s", server.URL, err)
+	}
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	bkgCtx := context.Background()
+	lc := logging.FactoryToStdout("clientTest")
+
+	testSecretStoreInfo := config.SecretStoreInfo{
+		Host:       host,
+		Port:       portNum,
+		Path:       "/test",
+		Protocol:   "http",
+		ServerName: "mockVaultServer",
+	}
+
+	tests := []struct {
+		name                string
+		authToken           string
+		tokenFile           string
+		expectedNewToken    string
+		expectedNilCallback bool
+		expectedRetry       bool
+		expectError         bool
+	}{
+		{
+			name:                "New secret client with testToken1, more than half of TTL remaining",
+			authToken:           "testToken1",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with the same first token again",
+			authToken:           "testToken1",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with testToken2, half of TTL remaining",
+			authToken:           "testToken2",
+			expectedNilCallback: false,
+			tokenFile:           "testdata/replacement.json",
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with testToken3, less than half of TTL remaining",
+			authToken:           "testToken3",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with expired token, no TTL remaining",
+			authToken:           "expiredToken",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with expired token, non-existing TokenFile path",
+			authToken:           "expiredToken",
+			tokenFile:           "testdata/non-existing.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with expired test token, but same expired replacement token",
+			authToken:           "test-token",
+			tokenFile:           "testdata/testToken.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "test-token",
+			expectedRetry:       false,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with unauthenticated token",
+			authToken:           "test-token",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         true,
+		},
+		{
+			name:                "New secret client with unrenewable token",
+			authToken:           "unrenewableToken",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       true,
+			expectError:         false,
+		},
+		{
+			name:                "New secret client with no TokenFile",
+			authToken:           "testToken1",
+			tokenFile:           "",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         false,
+		},
+	}
+
+	for _, test := range tests {
+		testSecretStoreInfo.TokenFile = test.tokenFile
+		// pinned local variables to avoid scopelint warnings
+		testToken := test.authToken
+		cfgHTTP := vault.SecretConfig{
+			Host:           host,
+			Port:           portNum,
+			Protocol:       "http",
+			Authentication: vault.AuthenticationInfo{AuthToken: testToken},
+		}
+		expectError := test.expectError
+		expectedCallbackNil := test.expectedNilCallback
+		expectedNewToken := test.expectedNewToken
+		expectedRetry := test.expectedRetry
+
+		t.Run(test.name, func(t *testing.T) {
+			sclient := NewVault(bkgCtx, cfgHTTP, lc)
+			_, err := sclient.Get(testSecretStoreInfo)
+
+			if expectError && err == nil {
+				t.Error("Expected error but none was received")
+			}
+
+			if !expectError && err != nil {
+				t.Errorf("Unexpected error: %s", err.Error())
+			}
+
+			tokenCallback := sclient.getDefaultTokenExpiredCallback(testSecretStoreInfo)
+			if expectedCallbackNil && tokenCallback != nil {
+				t.Error("expected nil token expired callback func, but found not nil")
+			}
+			if !expectedCallbackNil {
+				if tokenCallback == nil {
+					t.Error("expected some non-nil token expired callback func, but found nil")
+				} else {
+					repToken, retry := tokenCallback(testToken)
+
+					if repToken != expectedNewToken {
+						t.Errorf("expected a new token [%s] from callback but got [%s]", expectedNewToken, repToken)
+					}
+
+					if retry != expectedRetry {
+						t.Errorf("expected retry %v for a default token expired callback but got %v", expectedRetry, retry)
+					}
+
+					lc.Debug(fmt.Sprintf("repToken = %s, retry = %v", repToken, retry))
+				}
+			}
+		})
+	}
+	// wait for some time to allow renewToken to be run if any
+	time.Sleep(7 * time.Second)
+}
+
+func initTokenData(tokenPeriod int) *sync.Map {
 	var tokenDataMap sync.Map
 	// ttl > half of period
 	tokenDataMap.Store("testToken1", vault.TokenLookupMetadata{
@@ -121,261 +249,5 @@ func TestGetClient(t *testing.T) {
 		Period:    tokenPeriod,
 	})
 
-	server := getMockTokenServer(&tokenDataMap)
-	defer server.Close()
-
-	serverURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Errorf("error on parsing server url %s: %s", server.URL, err)
-	}
-	host, port, _ := net.SplitHostPort(serverURL.Host)
-	portNum, _ := strconv.Atoi(port)
-
-	bkgCtx := context.Background()
-	testSecretStoreInfo := config.SecretStoreInfo{
-		Host:       host,
-		Port:       portNum,
-		Path:       "/test",
-		Protocol:   "http",
-		ServerName: "mockVaultServer",
-	}
-	lc := logging.FactoryToStdout("clientTest")
-
-	testContainer := di.NewContainer(di.ServiceConstructorMap{
-		container.ConfigurationInterfaceName: func(get di.Get) interface{} {
-			return &configurationStruct{
-				secretStore: testSecretStoreInfo,
-			}
-		},
-		container.LoggingClientInterfaceName: func(get di.Get) interface{} {
-			return lc
-		},
-	})
-
-	tests := []struct {
-		name                string
-		authToken           string
-		tokenFile           string
-		expectedNilCallback bool
-		expectedNewToken    string
-		expectedRetry       bool
-		expectError         bool
-		expectedErrorType   error
-	}{
-		{
-			name:                "New secret client with testToken1, more than half of TTL remaining",
-			authToken:           "testToken1",
-			tokenFile:           "testdata/replacement.json",
-			expectedNilCallback: false,
-			expectedNewToken:    "replacement-token",
-			expectedRetry:       true,
-			expectError:         false,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with the same first token again",
-			authToken:           "testToken1",
-			tokenFile:           "testdata/replacement.json",
-			expectedNilCallback: false,
-			expectedNewToken:    "replacement-token",
-			expectedRetry:       true,
-			expectError:         false,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with testToken2, half of TTL remaining",
-			authToken:           "testToken2",
-			expectedNilCallback: false,
-			tokenFile:           "testdata/replacement.json",
-			expectedNewToken:    "replacement-token",
-			expectedRetry:       true,
-			expectError:         false,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with testToken3, less than half of TTL remaining",
-			authToken:           "testToken3",
-			tokenFile:           "testdata/replacement.json",
-			expectedNilCallback: false,
-			expectedNewToken:    "replacement-token",
-			expectedRetry:       true,
-			expectError:         false,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with expired token, no TTL remaining",
-			authToken:           "expiredToken",
-			tokenFile:           "testdata/replacement.json",
-			expectedNilCallback: false,
-			expectedNewToken:    "replacement-token",
-			expectedRetry:       true,
-			expectError:         true,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with expired token, non-existing TokenFile path",
-			authToken:           "expiredToken",
-			tokenFile:           "testdata/non-existing.json",
-			expectedNilCallback: false,
-			expectedNewToken:    "",
-			expectedRetry:       false,
-			expectError:         true,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with expired test token, but same expired replacement token",
-			authToken:           "test-token",
-			tokenFile:           "testdata/testToken.json",
-			expectedNilCallback: false,
-			expectedNewToken:    "test-token",
-			expectedRetry:       false,
-			expectError:         true,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with unauthenticated token",
-			authToken:           "test-token",
-			expectedNilCallback: true,
-			expectedNewToken:    "",
-			expectedRetry:       false,
-			expectError:         true,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with unrenewable token",
-			authToken:           "unrenewableToken",
-			expectedNilCallback: true,
-			expectedNewToken:    "",
-			expectedRetry:       true,
-			expectError:         false,
-			expectedErrorType:   nil,
-		},
-		{
-			name:                "New secret client with no TokenFile",
-			authToken:           "testToken1",
-			tokenFile:           "",
-			expectedNilCallback: true,
-			expectedNewToken:    "",
-			expectedRetry:       false,
-			expectError:         false,
-			expectedErrorType:   nil,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			testSecretStoreInfo.TokenFile = test.tokenFile
-			testContainer.Update(
-				di.ServiceConstructorMap{
-					container.ConfigurationInterfaceName: func(get di.Get) interface{} {
-						return &configurationStruct{
-							secretStore: testSecretStoreInfo,
-						}
-					},
-				})
-			cfgHTTP := vault.SecretConfig{
-				Host:           host,
-				Port:           portNum,
-				Protocol:       "http",
-				Authentication: vault.AuthenticationInfo{AuthToken: test.authToken},
-			}
-
-			sclient := NewSecretVaultClient(bkgCtx, cfgHTTP, testContainer)
-			_, err := sclient.GetClient()
-
-			if test.expectedErrorType != nil && err == nil {
-				t.Errorf("Expected error %v but none was received", test.expectedErrorType)
-			}
-
-			if !test.expectError && err != nil {
-				t.Errorf("Unexpected error: %s", err.Error())
-			}
-
-			if test.expectError && test.expectedErrorType != nil && err != nil {
-				eet := reflect.TypeOf(test.expectedErrorType)
-				aet := reflect.TypeOf(err)
-				if !aet.AssignableTo(eet) {
-					t.Errorf("Expected error of type %v, but got an error of type %v", eet, aet)
-				}
-			}
-
-			tokenCallback := sclient.getDefaultTokenExpiredCallback(testSecretStoreInfo)
-			if test.expectedNilCallback && tokenCallback != nil {
-				t.Error("expected nil token expired callback func, but found not nil")
-			}
-			if !test.expectedNilCallback {
-				if tokenCallback == nil {
-					t.Error("expected some non-nil token expired callback func, but found nil")
-				} else {
-					repToken, retry := tokenCallback(test.authToken)
-
-					if repToken != test.expectedNewToken {
-						t.Errorf("expected a new token [%s] from callback but got [%s]", test.expectedNewToken, repToken)
-					}
-
-					if retry != test.expectedRetry {
-						t.Errorf("expected retry %v for a default token expired callback but got %v", test.expectedRetry, retry)
-					}
-
-					lc.Debug(fmt.Sprintf("repToken = %s, retry = %v", repToken, retry))
-				}
-			}
-		})
-	}
-	// wait for some time to allow renewToken to be run if any
-	time.Sleep(7 * time.Second)
-}
-
-func getMockTokenServer(tokenDataMap *sync.Map) *httptest.Server {
-
-	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		urlPath := req.URL.String()
-		if req.Method == http.MethodGet && urlPath == "/v1/auth/token/lookup-self" {
-			token := req.Header.Get(vault.AuthTypeHeader)
-			sampleTokenLookup, exists := tokenDataMap.Load(token)
-			if !exists {
-				rw.WriteHeader(403)
-				_, _ = rw.Write([]byte("permission denied"))
-			} else {
-				resp := &vault.TokenLookupResponse{
-					Data: sampleTokenLookup.(vault.TokenLookupMetadata),
-				}
-				if ret, err := json.Marshal(resp); err != nil {
-					rw.WriteHeader(500)
-					_, _ = rw.Write([]byte(err.Error()))
-				} else {
-					rw.WriteHeader(200)
-					_, _ = rw.Write(ret)
-				}
-			}
-		} else if req.Method == http.MethodPost && urlPath == "/v1/auth/token/renew-self" {
-			token := req.Header.Get(vault.AuthTypeHeader)
-			sampleTokenLookup, exists := tokenDataMap.Load(token)
-			if !exists {
-				rw.WriteHeader(403)
-				_, _ = rw.Write([]byte("permission denied"))
-			} else {
-				currentTTL := sampleTokenLookup.(vault.TokenLookupMetadata).Ttl
-				if currentTTL <= 0 {
-					// already expired
-					rw.WriteHeader(403)
-					_, _ = rw.Write([]byte("permission denied"))
-				} else {
-					tokenPeriod := sampleTokenLookup.(vault.TokenLookupMetadata).Period
-
-					tokenDataMap.Store(token, vault.TokenLookupMetadata{
-						Renewable: true,
-						Ttl:       tokenPeriod,
-						Period:    tokenPeriod,
-					})
-					rw.WriteHeader(200)
-					_, _ = rw.Write([]byte("token renewed"))
-				}
-			}
-		} else {
-			rw.WriteHeader(404)
-			_, _ = rw.Write([]byte(fmt.Sprintf("Unknown urlPath: %s", urlPath)))
-		}
-	}))
-	return server
+	return &tokenDataMap
 }

--- a/bootstrap/handlers/secret/client/vaultclient_test.go
+++ b/bootstrap/handlers/secret/client/vaultclient_test.go
@@ -1,0 +1,381 @@
+//
+// Copyright (c) 2019 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied. See the License for the specific language governing permissions and limitations under
+// the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/logging"
+	"github.com/edgexfoundry/go-mod-bootstrap/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+
+	"github.com/edgexfoundry/go-mod-secrets/pkg/providers/vault"
+)
+
+type configurationStruct struct {
+	writable    writableInfo
+	logging     config.LoggingInfo
+	secretStore config.SecretStoreInfo
+}
+
+type writableInfo struct {
+	logLevel string
+}
+
+func (c *configurationStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	return true
+}
+
+func (c *configurationStruct) EmptyWritablePtr() interface{} {
+	return &writableInfo{}
+}
+
+func (c *configurationStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	return true
+}
+
+func (c *configurationStruct) GetBootstrap() interfaces.BootstrapConfiguration {
+	// temporary until we can make backwards-breaking configuration.toml change
+	return interfaces.BootstrapConfiguration{
+		Logging:     c.logging,
+		SecretStore: c.secretStore,
+	}
+}
+
+func (c *configurationStruct) GetLogLevel() string {
+	return c.writable.logLevel
+}
+
+func (c *configurationStruct) GetRegistryInfo() config.RegistryInfo {
+	return config.RegistryInfo{}
+}
+
+func TestGetClient(t *testing.T) {
+	// run in parallel with other tests
+	t.Parallel()
+
+	// setup
+	tokenPeriod := 6
+	var tokenDataMap sync.Map
+	// ttl > half of period
+	tokenDataMap.Store("testToken1", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 7 / 10,
+		Period:    tokenPeriod,
+	})
+	// ttl = half of period
+	tokenDataMap.Store("testToken2", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod / 2,
+		Period:    tokenPeriod,
+	})
+	// ttl < half of period
+	tokenDataMap.Store("testToken3", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       tokenPeriod * 3 / 10,
+		Period:    tokenPeriod,
+	})
+	// to be expired token
+	tokenDataMap.Store("toToExpiredToken", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       1,
+		Period:    tokenPeriod,
+	})
+	// expired token
+	tokenDataMap.Store("expiredToken", vault.TokenLookupMetadata{
+		Renewable: true,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+	// not renewable token
+	tokenDataMap.Store("unrenewableToken", vault.TokenLookupMetadata{
+		Renewable: false,
+		Ttl:       0,
+		Period:    tokenPeriod,
+	})
+
+	server := getMockTokenServer(&tokenDataMap)
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Errorf("error on parsing server url %s: %s", server.URL, err)
+	}
+	host, port, _ := net.SplitHostPort(serverURL.Host)
+	portNum, _ := strconv.Atoi(port)
+
+	bkgCtx := context.Background()
+	testSecretStoreInfo := config.SecretStoreInfo{
+		Host:       host,
+		Port:       portNum,
+		Path:       "/test",
+		Protocol:   "http",
+		ServerName: "mockVaultServer",
+	}
+	lc := logging.FactoryToStdout("clientTest")
+
+	testContainer := di.NewContainer(di.ServiceConstructorMap{
+		container.ConfigurationInterfaceName: func(get di.Get) interface{} {
+			return &configurationStruct{
+				secretStore: testSecretStoreInfo,
+			}
+		},
+		container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+			return lc
+		},
+	})
+
+	tests := []struct {
+		name                string
+		authToken           string
+		tokenFile           string
+		expectedNilCallback bool
+		expectedNewToken    string
+		expectedRetry       bool
+		expectError         bool
+		expectedErrorType   error
+	}{
+		{
+			name:                "New secret client with testToken1, more than half of TTL remaining",
+			authToken:           "testToken1",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with the same first token again",
+			authToken:           "testToken1",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with testToken2, half of TTL remaining",
+			authToken:           "testToken2",
+			expectedNilCallback: false,
+			tokenFile:           "testdata/replacement.json",
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with testToken3, less than half of TTL remaining",
+			authToken:           "testToken3",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         false,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with expired token, no TTL remaining",
+			authToken:           "expiredToken",
+			tokenFile:           "testdata/replacement.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "replacement-token",
+			expectedRetry:       true,
+			expectError:         true,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with expired token, non-existing TokenFile path",
+			authToken:           "expiredToken",
+			tokenFile:           "testdata/non-existing.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         true,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with expired test token, but same expired replacement token",
+			authToken:           "test-token",
+			tokenFile:           "testdata/testToken.json",
+			expectedNilCallback: false,
+			expectedNewToken:    "test-token",
+			expectedRetry:       false,
+			expectError:         true,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with unauthenticated token",
+			authToken:           "test-token",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         true,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with unrenewable token",
+			authToken:           "unrenewableToken",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       true,
+			expectError:         false,
+			expectedErrorType:   nil,
+		},
+		{
+			name:                "New secret client with no TokenFile",
+			authToken:           "testToken1",
+			tokenFile:           "",
+			expectedNilCallback: true,
+			expectedNewToken:    "",
+			expectedRetry:       false,
+			expectError:         false,
+			expectedErrorType:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testSecretStoreInfo.TokenFile = test.tokenFile
+			testContainer.Update(
+				di.ServiceConstructorMap{
+					container.ConfigurationInterfaceName: func(get di.Get) interface{} {
+						return &configurationStruct{
+							secretStore: testSecretStoreInfo,
+						}
+					},
+				})
+			cfgHTTP := vault.SecretConfig{
+				Host:           host,
+				Port:           portNum,
+				Protocol:       "http",
+				Authentication: vault.AuthenticationInfo{AuthToken: test.authToken},
+			}
+
+			sclient := NewSecretVaultClient(bkgCtx, cfgHTTP, testContainer)
+			_, err := sclient.GetClient()
+
+			if test.expectedErrorType != nil && err == nil {
+				t.Errorf("Expected error %v but none was received", test.expectedErrorType)
+			}
+
+			if !test.expectError && err != nil {
+				t.Errorf("Unexpected error: %s", err.Error())
+			}
+
+			if test.expectError && test.expectedErrorType != nil && err != nil {
+				eet := reflect.TypeOf(test.expectedErrorType)
+				aet := reflect.TypeOf(err)
+				if !aet.AssignableTo(eet) {
+					t.Errorf("Expected error of type %v, but got an error of type %v", eet, aet)
+				}
+			}
+
+			tokenCallback := sclient.getDefaultTokenExpiredCallback(testSecretStoreInfo)
+			if test.expectedNilCallback && tokenCallback != nil {
+				t.Error("expected nil token expired callback func, but found not nil")
+			}
+			if !test.expectedNilCallback {
+				if tokenCallback == nil {
+					t.Error("expected some non-nil token expired callback func, but found nil")
+				} else {
+					repToken, retry := tokenCallback(test.authToken)
+
+					if repToken != test.expectedNewToken {
+						t.Errorf("expected a new token [%s] from callback but got [%s]", test.expectedNewToken, repToken)
+					}
+
+					if retry != test.expectedRetry {
+						t.Errorf("expected retry %v for a default token expired callback but got %v", test.expectedRetry, retry)
+					}
+
+					lc.Debug(fmt.Sprintf("repToken = %s, retry = %v", repToken, retry))
+				}
+			}
+		})
+	}
+	// wait for some time to allow renewToken to be run if any
+	time.Sleep(7 * time.Second)
+}
+
+func getMockTokenServer(tokenDataMap *sync.Map) *httptest.Server {
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		urlPath := req.URL.String()
+		if req.Method == http.MethodGet && urlPath == "/v1/auth/token/lookup-self" {
+			token := req.Header.Get(vault.AuthTypeHeader)
+			sampleTokenLookup, exists := tokenDataMap.Load(token)
+			if !exists {
+				rw.WriteHeader(403)
+				_, _ = rw.Write([]byte("permission denied"))
+			} else {
+				resp := &vault.TokenLookupResponse{
+					Data: sampleTokenLookup.(vault.TokenLookupMetadata),
+				}
+				if ret, err := json.Marshal(resp); err != nil {
+					rw.WriteHeader(500)
+					_, _ = rw.Write([]byte(err.Error()))
+				} else {
+					rw.WriteHeader(200)
+					_, _ = rw.Write(ret)
+				}
+			}
+		} else if req.Method == http.MethodPost && urlPath == "/v1/auth/token/renew-self" {
+			token := req.Header.Get(vault.AuthTypeHeader)
+			sampleTokenLookup, exists := tokenDataMap.Load(token)
+			if !exists {
+				rw.WriteHeader(403)
+				_, _ = rw.Write([]byte("permission denied"))
+			} else {
+				currentTTL := sampleTokenLookup.(vault.TokenLookupMetadata).Ttl
+				if currentTTL <= 0 {
+					// already expired
+					rw.WriteHeader(403)
+					_, _ = rw.Write([]byte("permission denied"))
+				} else {
+					tokenPeriod := sampleTokenLookup.(vault.TokenLookupMetadata).Period
+
+					tokenDataMap.Store(token, vault.TokenLookupMetadata{
+						Renewable: true,
+						Ttl:       tokenPeriod,
+						Period:    tokenPeriod,
+					})
+					rw.WriteHeader(200)
+					_, _ = rw.Write([]byte("token renewed"))
+				}
+			}
+		} else {
+			rw.WriteHeader(404)
+			_, _ = rw.Write([]byte(fmt.Sprintf("Unknown urlPath: %s", urlPath)))
+		}
+	}))
+	return server
+}

--- a/bootstrap/handlers/secret/secret.go
+++ b/bootstrap/handlers/secret/secret.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/handlers/secret/client"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
@@ -44,7 +45,7 @@ func NewSecret() *SecretProvider {
 // BootstrapHandlers to obtain sensitive data, such as database credentials. This BootstrapHandler should be processed
 // before other BootstrapHandlers, possibly even first since it has not other dependencies.
 func (s *SecretProvider) BootstrapHandler(
-	_ context.Context,
+	ctx context.Context,
 	_ *sync.WaitGroup,
 	_ startup.Timer,
 	dic *di.Container) bool {
@@ -60,7 +61,10 @@ func (s *SecretProvider) BootstrapHandler(
 
 	// attempt to create a new SecretProvider client only if security is enabled.
 	if s.isSecurityEnabled() {
-		s.secretClient, err = vault.NewSecretClient(secretConfig)
+		s.secretClient, err = client.NewSecretVaultClient(ctx,
+			secretConfig,
+			dic).GetClient()
+
 		if err != nil {
 			lc.Error(fmt.Sprintf("unable to create SecretClient: %s", err.Error()))
 			return false

--- a/bootstrap/handlers/secret/secret.go
+++ b/bootstrap/handlers/secret/secret.go
@@ -61,9 +61,7 @@ func (s *SecretProvider) BootstrapHandler(
 
 	// attempt to create a new SecretProvider client only if security is enabled.
 	if s.isSecurityEnabled() {
-		s.secretClient, err = client.NewSecretVaultClient(ctx,
-			secretConfig,
-			dic).GetClient()
+		s.secretClient, err = client.NewVault(ctx, secretConfig, lc).Get(configuration.GetBootstrap().SecretStore)
 
 		if err != nil {
 			lc.Error(fmt.Sprintf("unable to create SecretClient: %s", err.Error()))

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/edgexfoundry/go-mod-configuration v0.0.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.34
 	github.com/edgexfoundry/go-mod-registry v0.1.17
-	github.com/edgexfoundry/go-mod-secrets v0.0.14
+	github.com/edgexfoundry/go-mod-secrets v0.0.15
 	github.com/gorilla/mux v1.7.1
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.8 // indirect


### PR DESCRIPTION
Update the constructor of vault.NewSecretClient to use the latest go-mod-secrets version `v0.0.15`

  - unit tests added for token expired call back cases
  - refactor to use the vault secret client into its package client under package secret

The real code changes are minimal with quite some unit testing code introduced.

Fixes issue #35


Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x]  Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The signature of `NewSecretClient()` of go-mod-secrets from older version (v0.0.14 and below) has been changed in version v0.0.15.  Currently code in `NewSecretClient()` no longer works for using version v0.0.15.

Issue Number:
#35 

## What is the new behavior?
In version `v0.0.15` of go-mod-secrets, the constructor to get `NewSecretClient` has been changed with getting a `NewSecretFactory()` call first and also the input arguments of `NewSecretClient` are expanded to take inputs and thus the changes are required here.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information