### PR TITLE
build: Update relevant files in go-mod-bootstrap for Go 1.13.

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG BASE=golang:1.12-alpine
+ARG BASE=golang:1.13-alpine
 FROM ${BASE}
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,5 +16,5 @@
 
 edgeXBuildGoMod (
     project: 'go-mod-bootstrap',
-    goVersion: '1.12'
+    goVersion: '1.13'
 )

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 
-go 1.12
+go 1.13


### PR DESCRIPTION
Fix #39 