### PR TITLE
Update go.mod to use go-mod-secrets version v0.0.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/edgexfoundry/go-mod-configuration v0.0.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.34
 	github.com/edgexfoundry/go-mod-registry v0.1.17
-	github.com/edgexfoundry/go-mod-secrets v0.0.15
+	github.com/edgexfoundry/go-mod-secrets v0.0.17
 	github.com/gorilla/mux v1.7.1
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.8 // indirect


### PR DESCRIPTION
The version `v0.0.15` of go-mod-secrets has the defect described in https://github.com/edgexfoundry/go-mod-secrets/issues/49 in that the API URL was not correctly built while looking up the Vault token.

This update to the version `v0.0.017` fixes this issue.

Closes: #52 

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The version `v0.0.15` of go-mod-secrets has the defect described in https://github.com/edgexfoundry/go-mod-secrets/issues/49 in that the API URL was not correctly built while looking up the Vault token, which would result in status code 403.

Issue Number: #52 


## What is the new behavior?
The new version 0.0.17 should fix the issue on looking up the token when the NewSecretClient is called.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information