### PR TITLE
Feature/fix issue 2200

### DIFF
--- a/bootstrap/container/certificate.go
+++ b/bootstrap/container/certificate.go
@@ -1,0 +1,29 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/di"
+)
+
+// CertificateProviderName contains the name of the interfaces.CertificateProvider implementation in the DIC.
+var CertificateProviderName = di.TypeInstanceToName((*interfaces.CertificateProvider)(nil))
+
+// CertificateProviderFrom helper function queries the DIC and returns the interfaces.CertificateProviderName
+// implementation.
+func CertificateProviderFrom(get di.Get) interfaces.CertificateProvider {
+	return get(CertificateProviderName).(interfaces.CertificateProvider)
+}

--- a/bootstrap/handlers/secret/certkeypair.go
+++ b/bootstrap/handlers/secret/certkeypair.go
@@ -1,0 +1,30 @@
+/********************************************************************************
+ *  Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package secret
+
+import "github.com/edgexfoundry/go-mod-bootstrap/config"
+
+func (s *SecretProvider) GetCertificateKeyPair(path string) (config.CertKeyPair, error) {
+	secrets, err := s.secretClient.GetSecrets(path, "cert", "key")
+	if err != nil {
+		return config.CertKeyPair{}, err
+	}
+
+	return config.CertKeyPair{
+		Cert: secrets["cert"],
+		Key:  secrets["key"],
+	}, nil
+
+}

--- a/bootstrap/handlers/secret/secret.go
+++ b/bootstrap/handlers/secret/secret.go
@@ -71,6 +71,9 @@ func (s *SecretProvider) BootstrapHandler(
 		container.CredentialsProviderName: func(get di.Get) interface{} {
 			return s
 		},
+		container.CertificateProviderName: func(get di.Get) interface{} {
+			return s
+		},
 	})
 
 	return true

--- a/bootstrap/interfaces/certificate.go
+++ b/bootstrap/interfaces/certificate.go
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright 2020 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package interfaces
+
+import "github.com/edgexfoundry/go-mod-bootstrap/config"
+
+// CertificateProvider interface provides an abstraction for obtaining certificate pair.
+type CertificateProvider interface {
+	// GetCertificateKeyPair retrieves certificate pair.
+	GetCertificateKeyPair(path string) (config.CertKeyPair, error)
+}

--- a/config/types.go
+++ b/config/types.go
@@ -134,3 +134,9 @@ type Credentials struct {
 	Username string
 	Password string
 }
+
+//CertKeyPair encapsulates public certificate/private key pair for an SSL certificate
+type CertKeyPair struct {
+	Cert string
+	Key  string
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
go-mod-boostrap only exposes interface of retrieving database credentials. 

Issue Number:
https://github.com/edgexfoundry/edgex-go/issues/2200

## What is the new behavior?
Adding new interface to expose a method of retrieving SSL cert key pair.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No


## Are there any specific instructions or things that should be known prior to reviewing?
The new interface CertificateProvider and the method of GetCertificateKeyPair() will be helpful for security-proxy-setup as well as other core microservices in the future.
1. The security-proxy-setup already adopted go-mod-bootstrap module. The new interface will not break its existing behaviors.
2. When the environment variable EDGEX_SECURITY_SECRET_STORE is set up as false which means security for EdgeX is off, the user will use a docker-compose file that doesn't include any security component.
3. There is a plan to add certificate key pair for core microservices ( such as data, metadata, commend etc.) to enable Https in the future. This interface and method can be used for such security enhancement in the future. 

## Other information