### PR TITLE
fix(logging): Logger not configured properly

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -59,8 +59,8 @@ func NewProcessor(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	configUpdated UpdatedStream,
-) Processor {
-	return Processor{
+) *Processor {
+	return &Processor{
 		Logger:        lc,
 		flags:         flags,
 		environment:   environment,
@@ -71,7 +71,7 @@ func NewProcessor(
 	}
 }
 
-func (cp Processor) Process(serviceKey string, configStem string, serviceConfig interfaces.Configuration) error {
+func (cp *Processor) Process(serviceKey string, configStem string, serviceConfig interfaces.Configuration) error {
 	// Create some shorthand for frequently used items
 	environment := cp.environment
 	lc := cp.Logger
@@ -157,7 +157,7 @@ func (cp Processor) Process(serviceKey string, configStem string, serviceConfig 
 }
 
 // createProviderClient creates and returns a configuration.Client instance and logs Client connection information
-func (cp Processor) createProviderClient(
+func (cp *Processor) createProviderClient(
 	serviceKey string,
 	configStem string,
 	providerConfig configTypes.ServiceConfig) (configuration.Client, error) {
@@ -174,7 +174,7 @@ func (cp Processor) createProviderClient(
 }
 
 // LoadFromFile attempts to read and unmarshal toml-based configuration into a configuration struct.
-func (cp Processor) loadFromFile(config interfaces.Configuration) error {
+func (cp *Processor) loadFromFile(config interfaces.Configuration) error {
 	configDir := cp.flags.ConfigDirectory()
 	envValue := os.Getenv(envConfDir)
 	if len(envValue) > 0 {
@@ -224,7 +224,7 @@ func (cp Processor) loadFromFile(config interfaces.Configuration) error {
 // ProcessWithProvider puts configuration if doesnt exist in provider (i.e. self-seed) or
 // gets configuration from provider and updates the service's configuration with environment overrides after receiving
 // them from the provider so that environment override supersede any changes made in the provider.
-func (cp Processor) processWithProvider(
+func (cp *Processor) processWithProvider(
 	configClient configuration.Client,
 	serviceConfig interfaces.Configuration,
 	overrideCount int) error {
@@ -272,7 +272,7 @@ func (cp Processor) processWithProvider(
 // service's configuration struct's writable sub-struct.  It's assumed the log level is universally part of the
 // writable struct and this function explicitly updates the loggingClient's log level when new configuration changes
 // are received.
-func (cp Processor) listenForChanges(serviceConfig interfaces.Configuration, configClient configuration.Client) {
+func (cp *Processor) listenForChanges(serviceConfig interfaces.Configuration, configClient configuration.Client) {
 	lc := cp.Logger
 
 	cp.wg.Add(1)
@@ -317,6 +317,6 @@ func (cp Processor) listenForChanges(serviceConfig interfaces.Configuration, con
 }
 
 // logConfigInfo logs the config info message with number over overrides that occurred.
-func (cp Processor) logConfigInfo(message string, overrideCount int) {
+func (cp *Processor) logConfigInfo(message string, overrideCount int) {
 	cp.Logger.Info(fmt.Sprintf("%s (%d environment overrides applied)", message, overrideCount))
 }


### PR DESCRIPTION
Changed config.Processor reciever to be a pointer so the change to logger is propagated to caller.

closes #61

Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Logger not configured properly after processing the configuration.

Issue Number: #61 


## What is the new behavior?

Logger now properly configure per the processed configuration

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information