### PR TITLE
fix: Allow overrides that have empty/blank value

### DIFF
--- a/bootstrap/config/environment.go
+++ b/bootstrap/config/environment.go
@@ -62,8 +62,12 @@ func NewEnvironment() *Environment {
 	}
 	for _, env := range osEnv {
 		kv := strings.Split(env, "=")
-		if len(kv) == 2 && len(kv[0]) > 0 && len(kv[1]) > 0 {
-			e.env[kv[0]] = kv[1]
+		if len(kv) > 0 && len(kv[0]) > 0 {
+			if len(kv) > 1 && len(kv[1]) > 0 {
+				e.env[kv[0]] = kv[1]
+			} else {
+				e.env[kv[0]] = "" // Handle case when value is blank, i.e. Service_Host=""
+			}
 		}
 	}
 	return e

--- a/bootstrap/config/environment_test.go
+++ b/bootstrap/config/environment_test.go
@@ -339,3 +339,46 @@ func TestOverrideConfigurationUppercase(t *testing.T) {
 	assert.Equal(t, expectedAuthType, serviceConfig.SecretStore.Authentication.AuthType)
 	assert.Equal(t, expectedAuthToken, serviceConfig.SecretStore.Authentication.AuthToken)
 }
+
+func TestOverrideConfigurationWithBlankValue(t *testing.T) {
+	_, _, lc := initializeTest()
+
+	expectedOverrideCount := 3
+	expectedHost := ""
+	expectedAuthType := ""
+	expectedAuthToken := ""
+
+	serviceConfig := struct {
+		Registry    config.RegistryInfo
+		List        []string
+		FloatVal    float32
+		SecretStore config.SecretStoreInfo
+	}{
+		Registry: config.RegistryInfo{
+			Host: "localhost",
+			Port: 8500,
+			Type: "consul",
+		},
+		List:     []string{"val1"},
+		FloatVal: float32(11.11),
+		SecretStore: config.SecretStoreInfo{
+			Authentication: vault.AuthenticationInfo{
+				AuthType:  "none",
+				AuthToken: expectedAuthToken,
+			},
+		},
+	}
+
+	_ = os.Setenv("REGISTRY_HOST", expectedHost)
+	_ = os.Setenv("SECRETSTORE_AUTHENTICATION_AUTHTYPE", expectedAuthType)
+	_ = os.Setenv("SECRETSTORE_AUTHENTICATION_AUTHTOKEN", expectedAuthToken)
+
+	env := NewEnvironment()
+	actualCount, err := env.OverrideConfiguration(lc, &serviceConfig)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedOverrideCount, actualCount)
+	assert.Equal(t, expectedHost, serviceConfig.Registry.Host)
+	assert.Equal(t, expectedAuthType, serviceConfig.SecretStore.Authentication.AuthType)
+	assert.Equal(t, expectedAuthToken, serviceConfig.SecretStore.Authentication.AuthToken)
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Env overrides with blank values such as Service_Host="" were ignored.

Issue Number: #74 


## What is the new behavior?

Env overrides with blank values no work.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information