### PR TITLE
fix: Don't use hostname for webserver ListenAndServe

### DIFF
--- a/bootstrap/handlers/httpserver/httpserver.go
+++ b/bootstrap/handlers/httpserver/httpserver.go
@@ -77,7 +77,12 @@ func (b *HttpServer) BootstrapHandler(
 	}
 
 	bootstrapConfig := container.ConfigurationFrom(dic.Get).GetBootstrap()
-	addr := bootstrapConfig.Service.Host + ":" + strconv.Itoa(bootstrapConfig.Service.Port)
+
+	// Do not use Service.Host in the address.
+	// Using hostname it is not recommended because it will create a listener for at most one of the host's IP addresses
+	// which becomes an issue when using distributed orchestration.
+	addr := ":" + strconv.Itoa(bootstrapConfig.Service.Port)
+
 	timeout := time.Millisecond * time.Duration(bootstrapConfig.Service.Timeout)
 	server := &http.Server{
 		Addr:         addr,

--- a/bootstrap/handlers/httpserver/httpserver.go
+++ b/bootstrap/handlers/httpserver/httpserver.go
@@ -81,7 +81,7 @@ func (b *HttpServer) BootstrapHandler(
 	// Do not use Service.Host in the address.
 	// Using hostname it is not recommended because it will create a listener for at most one of the host's IP addresses
 	// which becomes an issue when using distributed orchestration.
-	addr := ":" + strconv.Itoa(bootstrapConfig.Service.Port)
+	addr := "0.0.0.0:" + strconv.Itoa(bootstrapConfig.Service.Port)
 
 	timeout := time.Millisecond * time.Duration(bootstrapConfig.Service.Timeout)
 	server := &http.Server{


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #76

ListenAndServe was lock to specific adapter for the specified hostname 

## What is the new behavior?

ListenAndServe now not using hostname so available on any of the host system's adapters

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information