### PR TITLE
fix: configurable ip address for ListenAndServe, fixes #83

### DIFF
--- a/bootstrap/handlers/httpserver/httpserver.go
+++ b/bootstrap/handlers/httpserver/httpserver.go
@@ -78,10 +78,15 @@ func (b *HttpServer) BootstrapHandler(
 
 	bootstrapConfig := container.ConfigurationFrom(dic.Get).GetBootstrap()
 
-	// Do not use Service.Host in the address.
-	// Using hostname it is not recommended because it will create a listener for at most one of the host's IP addresses
-	// which becomes an issue when using distributed orchestration.
-	addr := "0.0.0.0:" + strconv.Itoa(bootstrapConfig.Service.Port)
+	// this allows env override to explicitly set the value used
+	// for ListenAndServe as needed for different deployments
+	port := strconv.Itoa(bootstrapConfig.Service.Port)
+	addr := bootstrapConfig.Service.ServerBindAddr + ":" + port
+	// for backwards compatibility, the Host value is the default value if
+	// the ServerBindAddr value is not specified
+	if bootstrapConfig.Service.ServerBindAddr == "" {
+		addr = bootstrapConfig.Service.Host + ":" + port
+	}
 
 	timeout := time.Millisecond * time.Duration(bootstrapConfig.Service.Timeout)
 	server := &http.Server{

--- a/config/types.go
+++ b/config/types.go
@@ -33,6 +33,9 @@ type ServiceInfo struct {
 	Host string
 	// Port is the HTTP port of the service.
 	Port int
+	// ServerBindAddr specifies an IP address or hostname
+	// for ListenAndServe to bind to, such as 0.0.0.0
+	ServerBindAddr string
 	// The protocol that should be used to call this service
 	Protocol string
 	// StartupMsg specifies a string to log once service


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The `ListenAndServe` IP address defaults to binding to an all-interface listener value of `0.0.0.0`.

Issue Number: #83 


## What is the new behavior?

This change adds a `ServerBindAddr` configurable value. (This name is up for debate, if others have input feel free)

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?

No

## Are there any specific instructions or things that should be known prior to reviewing?

No

## Other information

N/A