### PR TITLE
fix: Startup Duration and Interval never updated from default values

### DIFF
--- a/bootstrap/config/provider.go
+++ b/bootstrap/config/provider.go
@@ -16,6 +16,8 @@ package config
 import (
 	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/environment"
 )
 
 // ProviderInfo encapsulates the usage of the Configuration Provider information
@@ -24,7 +26,7 @@ type ProviderInfo struct {
 }
 
 // NewProviderInfo creates a new ProviderInfo and initializes it
-func NewProviderInfo(lc logger.LoggingClient, environment *Environment, providerUrl string) (*ProviderInfo, error) {
+func NewProviderInfo(lc logger.LoggingClient, envVars *environment.Variables, providerUrl string) (*ProviderInfo, error) {
 	var err error
 	configProviderInfo := ProviderInfo{}
 
@@ -35,8 +37,8 @@ func NewProviderInfo(lc logger.LoggingClient, environment *Environment, provider
 		}
 	}
 
-	// override file-based configuration with Environment variables.
-	configProviderInfo.serviceConfig, err = environment.OverrideConfigProviderInfo(lc, configProviderInfo.serviceConfig)
+	// override file-based configuration with Variables variables.
+	configProviderInfo.serviceConfig, err = envVars.OverrideConfigProviderInfo(lc, configProviderInfo.serviceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrap/config/provider_test.go
+++ b/bootstrap/config/provider_test.go
@@ -20,14 +20,26 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/logging"
+)
+
+const (
+	envKeyConfigUrl = "EDGEX_CONFIGURATION_PROVIDER"
+	goodUrlValue    = "consul.http://localhost:8500"
+	badUrlValue     = "Not a url"
+
+	expectedTypeValue     = "consul"
+	expectedHostValue     = "localhost"
+	expectedPortValue     = 8500
+	expectedProtocolValue = "http"
 )
 
 func TestNewConfigProviderInfoUrl(t *testing.T) {
 	lc := logging.FactoryToStdout("unit-test")
 
-	env := NewEnvironment()
-	target, err := NewProviderInfo(lc, env, goodUrlValue)
+	envVars := environment.NewVariables()
+	target, err := NewProviderInfo(lc, envVars, goodUrlValue)
 	require.NoError(t, err)
 
 	actual := target.ServiceConfig()
@@ -44,8 +56,8 @@ func TestNewConfigProviderInfoEnv(t *testing.T) {
 	err := os.Setenv(envKeyConfigUrl, goodUrlValue)
 	require.NoError(t, err)
 
-	env := NewEnvironment()
-	target, err := NewProviderInfo(lc, env, goodUrlValue)
+	envVars := environment.NewVariables()
+	target, err := NewProviderInfo(lc, envVars, goodUrlValue)
 	require.NoError(t, err)
 
 	actual := target.ServiceConfig()
@@ -59,8 +71,8 @@ func TestNewConfigProviderInfoEnv(t *testing.T) {
 func TestNewConfigProviderInfoBadUrl(t *testing.T) {
 	lc := logging.FactoryToStdout("unit-test")
 
-	env := NewEnvironment()
-	_, err := NewProviderInfo(lc, env, badUrlValue)
+	envVars := environment.NewVariables()
+	_, err := NewProviderInfo(lc, envVars, badUrlValue)
 	assert.Error(t, err)
 }
 
@@ -71,7 +83,7 @@ func TestNewConfigProviderInfoBadEnvUrl(t *testing.T) {
 	err := os.Setenv(envKeyConfigUrl, badUrlValue)
 	require.NoError(t, err)
 
-	env := NewEnvironment()
-	_, err = NewProviderInfo(lc, env, goodUrlValue)
+	envVars := environment.NewVariables()
+	_, err = NewProviderInfo(lc, envVars, goodUrlValue)
 	assert.Error(t, err)
 }

--- a/bootstrap/interfaces/configuration.go
+++ b/bootstrap/interfaces/configuration.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2020 Intel Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -16,17 +17,6 @@ package interfaces
 
 import "github.com/edgexfoundry/go-mod-bootstrap/config"
 
-// BootstrapConfiguration defines the configuration elements required by the bootstrap.
-type BootstrapConfiguration struct {
-	Clients     map[string]config.ClientInfo
-	Service     config.ServiceInfo
-	Config      config.ConfigProviderInfo
-	Registry    config.RegistryInfo
-	Logging     config.LoggingInfo
-	SecretStore config.SecretStoreInfo
-	Startup     config.StartupInfo
-}
-
 // Configuration interface provides an abstraction around a configuration struct.
 type Configuration interface {
 	// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
@@ -42,7 +32,7 @@ type Configuration interface {
 	UpdateWritableFromRaw(rawWritable interface{}) bool
 
 	// GetBootstrap returns the configuration elements required by the bootstrap.
-	GetBootstrap() BootstrapConfiguration
+	GetBootstrap() config.BootstrapConfiguration
 
 	// GetLogLevel returns the current ConfigurationStruct's log level.
 	GetLogLevel() string

--- a/bootstrap/logging/factory.go
+++ b/bootstrap/logging/factory.go
@@ -17,10 +17,11 @@ package logging
 import (
 	"path/filepath"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/models"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/config"
 )
 
 // FactoryToStdout returns a logger.LoggingClient that outputs to stdout.
@@ -29,9 +30,8 @@ func FactoryToStdout(serviceKey string) logger.LoggingClient {
 }
 
 // FactoryFromConfiguration returns a logger.LoggingClient based on configuration settings.
-func FactoryFromConfiguration(serviceKey string, config interfaces.Configuration) logger.LoggingClient {
+func FactoryFromConfiguration(serviceKey string, bootstrapConfig config.BootstrapConfiguration, level string) logger.LoggingClient {
 	var target string
-	bootstrapConfig := config.GetBootstrap()
 	if bootstrapConfig.Logging.EnableRemote {
 		target = bootstrapConfig.Clients["Logging"].Url() + clients.ApiLoggingRoute
 	} else {
@@ -39,5 +39,5 @@ func FactoryFromConfiguration(serviceKey string, config interfaces.Configuration
 			target, _ = filepath.Abs(bootstrapConfig.Logging.File)
 		}
 	}
-	return logger.NewClient(serviceKey, bootstrapConfig.Logging.EnableRemote, target, config.GetLogLevel())
+	return logger.NewClient(serviceKey, bootstrapConfig.Logging.EnableRemote, target, level)
 }

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2020 Intel Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -27,7 +28,7 @@ import (
 	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/registry"
 
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
@@ -40,7 +41,7 @@ func createRegistryClient(
 	serviceKey string,
 	serviceConfig interfaces.Configuration,
 	registryUrl string,
-	environment *config.Environment,
+	envVars *environment.Variables,
 	lc logger.LoggingClient) (registry.Client, error) {
 	var err error
 	bootstrapConfig := serviceConfig.GetBootstrap()
@@ -67,8 +68,8 @@ func createRegistryClient(
 	}
 
 	// TODO: Remove this block for release v2.0.0
-	// For backwards compatibility, registry information can be override with environment variable.
-	registryUrl = environment.GetRegistryProviderInfoOverride(lc)
+	// For backwards compatibility, registry information can be override with envVars variable.
+	registryUrl = envVars.GetRegistryProviderInfoOverride(lc)
 	if len(registryUrl) > 0 {
 		registryConfig, err = OverrideRegistryConfigWithUrl(registryConfig, registryUrl)
 		if err != nil {
@@ -113,7 +114,7 @@ func RegisterWithRegistry(
 	startupTimer startup.Timer,
 	config interfaces.Configuration,
 	registryUrl string,
-	environment *config.Environment,
+	envVars *environment.Variables,
 	lc logger.LoggingClient,
 	serviceKey string) (registry.Client, error) {
 
@@ -129,7 +130,7 @@ func RegisterWithRegistry(
 		return nil
 	}
 
-	registryClient, err := createRegistryClient(serviceKey, config, registryUrl, environment, lc)
+	registryClient, err := createRegistryClient(serviceKey, config, registryUrl, envVars, lc)
 	if err != nil {
 		return nil, fmt.Errorf("createRegistryClient failed: %v", err.Error())
 	}

--- a/bootstrap/registration/registry_test.go
+++ b/bootstrap/registration/registry_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 Intel Corporation
+// Copyright (c) 2020 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,8 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	envConfig "github.com/edgexfoundry/go-mod-bootstrap/bootstrap/config"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/config"
 )
 
@@ -74,10 +73,10 @@ func TestCreateRegistryClient(t *testing.T) {
 		},
 	}
 
-	env := envConfig.NewEnvironment()
+	envVars := environment.NewVariables()
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			actual, err := createRegistryClient("unit-test", serviceConfig, test.RegistryUrl, env, lc)
+			actual, err := createRegistryClient("unit-test", serviceConfig, test.RegistryUrl, envVars, lc)
 			if len(test.ExpectedError) > 0 {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.ExpectedError)
@@ -153,8 +152,8 @@ func (ut unitTestConfiguration) UpdateWritableFromRaw(rawWritable interface{}) b
 	panic("should not be called")
 }
 
-func (ut unitTestConfiguration) GetBootstrap() interfaces.BootstrapConfiguration {
-	return interfaces.BootstrapConfiguration{
+func (ut unitTestConfiguration) GetBootstrap() config.BootstrapConfiguration {
+	return config.BootstrapConfiguration{
 		Service:  ut.Service,
 		Registry: ut.Registry,
 	}

--- a/bootstrap/startup/timer.go
+++ b/bootstrap/startup/timer.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2020 Intel Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,7 +15,11 @@
 
 package startup
 
-import "time"
+import (
+	"time"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/environment"
+)
 
 // Timer contains references to dependencies required by the startup timer implementation.
 type Timer struct {
@@ -24,11 +29,13 @@ type Timer struct {
 }
 
 // NewStartUpTimer is a factory method that returns an initialized Timer receiver struct.
-func NewStartUpTimer(retryIntervalInSeconds, maxWaitInSeconds int) Timer {
+func NewStartUpTimer(serviceKey string) Timer {
+	startup := environment.GetStartupInfo(serviceKey)
+
 	return Timer{
 		startTime: time.Now(),
-		duration:  time.Second * time.Duration(maxWaitInSeconds),
-		interval:  time.Second * time.Duration(retryIntervalInSeconds),
+		duration:  time.Second * time.Duration(startup.Duration),
+		interval:  time.Second * time.Duration(startup.Interval),
 	}
 }
 
@@ -45,14 +52,4 @@ func (t Timer) HasNotElapsed() bool {
 // SleepForInterval pauses execution for the interval specified during construction.
 func (t Timer) SleepForInterval() {
 	time.Sleep(t.interval)
-}
-
-//	Update the wait/interval for the timer,
-func (t Timer) UpdateTimer(maxWaitInSeconds int, retryIntervalInSeconds int) {
-	if maxWaitInSeconds > 0 {
-		t.duration = time.Second * time.Duration(maxWaitInSeconds)
-	}
-	if retryIntervalInSeconds > 0 {
-		t.interval = time.Second * time.Duration(retryIntervalInSeconds)
-	}
 }

--- a/config/types.go
+++ b/config/types.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2018 Dell Inc.
+ * Copyright 2020 Intel Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -83,12 +84,6 @@ type LoggingInfo struct {
 	File         string
 }
 
-// StartupInfo provides the startup timer values which are applied to the StartupTimer created at boot.
-type StartupInfo struct {
-	Duration int
-	Interval int
-}
-
 // ClientInfo provides the host and port of another service in the eco-system.
 type ClientInfo struct {
 	// Host is the hostname or IP address of a service.
@@ -141,4 +136,14 @@ type Credentials struct {
 type CertKeyPair struct {
 	Cert string
 	Key  string
+}
+
+// BootstrapConfiguration defines the configuration elements required by the bootstrap.
+type BootstrapConfiguration struct {
+	Clients     map[string]ClientInfo
+	Service     ServiceInfo
+	Config      ConfigProviderInfo
+	Registry    RegistryInfo
+	Logging     LoggingInfo
+	SecretStore SecretStoreInfo
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Changing the Startup configuration has no impact and neither does using the startup env variables.  
The Startup configuration is not useful as it is needed prior to loading the configuration. 
Update of timer with values from Env Vars doesn't work.

Issue Number: #85


## What is the new behavior?

Service Startup config is not loaded when timer is created/updated so have been removed.
NewStartUpTimer now checks and uses Env values form start so update of timer no longer needed.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

Startup configuration never worked, so removing it will is not a breaking change

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?

Code restructuring was required to avoid circular imports
Requires changes to each service for the change in signature of NewStartUpTimer 

## Other information