### PR TITLE
fix: Increase default startup duration to 60 seconds

### DIFF
--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	bootTimeoutSecondsDefault = 30
+	bootTimeoutSecondsDefault = 60
 	bootRetrySecondsDefault   = 1
 	defaultConfDirValue       = "./res"
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

The default startup duration of 30 seconds is not sufficient for low resource systems.

Issue Number:  #98


## What is the new behavior?

Default startup is now 60 seconds which has be proven to work for some low resource systems. 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information