### PR TITLE
fix: Handle env override values which have the '=' character

### DIFF
--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -66,15 +66,16 @@ func NewVariables() *Variables {
 		variables: make(map[string]string, len(osEnv)),
 	}
 	for _, env := range osEnv {
-		kv := strings.Split(env, "=")
-		if len(kv) > 0 && len(kv[0]) > 0 {
-			if len(kv) > 1 && len(kv[1]) > 0 {
-				e.variables[kv[0]] = kv[1]
-			} else {
-				e.variables[kv[0]] = "" // Handle case when value is blank, i.e. Service_Host=""
-			}
+		// Can not use Split() on '=' since the value may have an '=' in it, so changed to use Index()
+		index := strings.Index(env, "=")
+		if index == -1 {
+			continue
 		}
+		key := env[:index]
+		value := env[index+1:]
+		e.variables[key] = value
 	}
+
 	return e
 }
 

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -452,3 +452,30 @@ func TestOverrideConfigurationWithBlankValue(t *testing.T) {
 	assert.Equal(t, expectedAuthType, serviceConfig.SecretStore.Authentication.AuthType)
 	assert.Equal(t, expectedAuthToken, serviceConfig.SecretStore.Authentication.AuthToken)
 }
+
+func TestOverrideConfigurationWithEqualInValue(t *testing.T) {
+	_, lc := initializeTest()
+
+	expectedOverrideCount := 1
+	expectedAuthToken := "123456=789"
+
+	serviceConfig := struct {
+		SecretStore config.SecretStoreInfo
+	}{
+		SecretStore: config.SecretStoreInfo{
+			Authentication: vault.AuthenticationInfo{
+				AuthType:  "none",
+				AuthToken: expectedAuthToken,
+			},
+		},
+	}
+
+	_ = os.Setenv("SECRETSTORE_AUTHENTICATION_AUTHTOKEN", expectedAuthToken)
+
+	env := NewVariables()
+	actualCount, err := env.OverrideConfiguration(lc, &serviceConfig)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedOverrideCount, actualCount)
+	assert.Equal(t, expectedAuthToken, serviceConfig.SecretStore.Authentication.AuthToken)
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/edgex-examples/blob/master/.github/CONTRIBUTING.md.

## What is the current behavior?

Env overrides values which have `=` in them are chopped off to have just the string before the `=`.

## Issue Number:  #111

## What is the new behavior?

Env overrides values which have `=` in them are kept in tact.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
Are there any new imports or modules? If so, what are they used for and why?

no
## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information