### PR TITLE
fix: Accept argument lists with a -r substring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,10 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# GoLand/Jetbrains IDE
+# IDE
 /.idea
+.vscode
 
 go.sum
 VERSION
+

--- a/bootstrap/flags/flags_test.go
+++ b/bootstrap/flags/flags_test.go
@@ -96,3 +96,30 @@ func TestNewOverrideRegistry(t *testing.T) {
 
 	assert.Equal(t, expectedRegistryUrl, actual.RegistryUrl())
 }
+
+func TestDashR(t *testing.T) {
+	expectedConfigDirectory := "/foo/ba-r/"
+	actual := newSUT([]string{"-confdir", "/foo/ba-r/"})
+
+	assert.Equal(t, expectedConfigDirectory, actual.ConfigDirectory())
+}
+
+func TestConfDirEquals(t *testing.T) {
+	expectedConfigDirectory := "/foo/ba-r/"
+	actual := newSUT([]string{"-confdir=/foo/ba-r/"})
+
+	assert.Equal(t, expectedConfigDirectory, actual.ConfigDirectory())
+}
+
+func TestConfCommonScenario(t *testing.T) {
+	expectedConfigProviderUrl := "consul.http://edgex-core-consul:8500"
+	expectedConfigDirectory := "/res"
+	expectedRegistryUrl := ""
+
+	actual := newSUT([]string{"-cp=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res"})
+
+	assert.Equal(t, expectedConfigProviderUrl, actual.ConfigProviderUrl())
+	assert.True(t, actual.UseRegistry())
+	assert.Equal(t, expectedRegistryUrl, actual.RegistryUrl())
+	assert.Equal(t, expectedConfigDirectory, actual.ConfigDirectory())
+}


### PR DESCRIPTION
Signed-off-by: André Srinivasan <andre@redislabs.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?

When an argument list contains a substring with _-r_ it is treated as the `-registry` flag. For example

```
service -configdir /foo/ba-r/
```

The _-r_ in _ba-r_ is seen as the `-registry` flag

## Issue Number:

Resolves #78 

## What is the new behavior?

Explicitly check for the regexp `^-(cp|configProvider)` and `^-(r|registry)`

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions

## Other information

Output `go test -v` before code changes

```
=== RUN   TestNewAllFlags
--- PASS: TestNewAllFlags (0.00s)
=== RUN   TestNewDefaultsNoFlags
--- PASS: TestNewDefaultsNoFlags (0.00s)
=== RUN   TestNewDefaultForCP
--- PASS: TestNewDefaultForCP (0.00s)
=== RUN   TestNewOverrideForCP
--- PASS: TestNewOverrideForCP (0.00s)
=== RUN   TestNewDefaultForConfigProvider
--- PASS: TestNewDefaultForConfigProvider (0.00s)
=== RUN   TestNewOverrideConfigProvider
--- PASS: TestNewOverrideConfigProvider (0.00s)
=== RUN   TestNewOverrideRegistry
--- PASS: TestNewOverrideRegistry (0.00s)
=== RUN   TestDashR
    flags_test.go:104:
            Error Trace:    flags_test.go:104
            Error:          Not equal:
                            expected: "/foo/ba-r/"
                            actual  : "-r=."

                            Diff:
                            --- Expected
                            +++ Actual
                            @@ -1 +1 @@
                            -/foo/ba-r/
                            +-r=.
            Test:           TestDashR
--- FAIL: TestDashR (0.00s)
=== RUN   TestConfDirEquals
--- PASS: TestConfDirEquals (0.00s)
FAIL
exit status 1
FAIL    github.com/edgexfoundry/go-mod-bootstrap/bootstrap/flags    0.004s
```

Output `go test -v` after code changes

```
=== RUN   TestNewAllFlags
--- PASS: TestNewAllFlags (0.00s)
=== RUN   TestNewDefaultsNoFlags
--- PASS: TestNewDefaultsNoFlags (0.00s)
=== RUN   TestNewDefaultForCP
--- PASS: TestNewDefaultForCP (0.00s)
=== RUN   TestNewOverrideForCP
--- PASS: TestNewOverrideForCP (0.00s)
=== RUN   TestNewDefaultForConfigProvider
--- PASS: TestNewDefaultForConfigProvider (0.00s)
=== RUN   TestNewOverrideConfigProvider
--- PASS: TestNewOverrideConfigProvider (0.00s)
=== RUN   TestNewOverrideRegistry
--- PASS: TestNewOverrideRegistry (0.00s)
=== RUN   TestDashR
--- PASS: TestDashR (0.00s)
=== RUN   TestConfDirEquals
--- PASS: TestConfDirEquals (0.00s)
PASS
ok  	github.com/edgexfoundry/go-mod-bootstrap/bootstrap/flags	0.004s
```



