### PR TITLE
feat: Allow service to pass in initial logging client

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -17,6 +17,7 @@ package bootstrap
 
 import (
 	"context"
+	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/logging"
 	"os"
 	"os/signal"
 	"sync"
@@ -30,7 +31,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/flags"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/logging"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/registration"
 	"github.com/edgexfoundry/go-mod-bootstrap/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/di"
@@ -91,7 +91,11 @@ func RunAndReturnWaitGroup(
 	var wg sync.WaitGroup
 	deferred := func() {}
 
-	lc := logging.FactoryToStdout(serviceKey)
+	// Check if service provided an initial Logging Client to use. If not create one.
+	lc := container.LoggingClientFrom(dic.Get)
+	if lc == nil {
+		lc = logging.FactoryToStdout(serviceKey)
+	}
 
 	translateInterruptToCancel(ctx, &wg, cancel)
 

--- a/di/container.go
+++ b/di/container.go
@@ -111,12 +111,13 @@ func (c *Container) Update(serviceConstructors ServiceConstructorMap) {
 }
 
 // get looks up the requested serviceName and, if it exists, returns a constructed instance.  If the requested service
-// does not exist, it panics.  Get wraps instance construction in a singleton; the implementation assumes an instance,
+// does not exist, it returns nil.  Get wraps instance construction in a singleton; the implementation assumes an instance,
 // once constructed, will be reused and returned for all subsequent get(serviceName) calls.
 func (c *Container) get(serviceName string) interface{} {
 	service, ok := c.serviceMap[serviceName]
 	if !ok {
-		panic("attempt to get unknown service \"" + serviceName + "\"")
+		// Returning nil allows the DIC to be queried for a object and not panic if it doesn't exist.
+		return nil
 	}
 	if service.instance == nil {
 		service.instance = service.constructor(c.get)

--- a/di/container_test.go
+++ b/di/container_test.go
@@ -22,10 +22,11 @@ import (
 
 const serviceName = "serviceName"
 
-func TestGetUnknownServicePanics(t *testing.T) {
+func TestGetUnknownService(t *testing.T) {
 	sut := NewContainer(ServiceConstructorMap{})
 
-	assert.Panics(t, func() { sut.Get("unknownService") })
+	result := sut.Get("unknownService")
+	assert.Nil(t, result)
 }
 
 func TestGetKnownServiceReturnsExpectedConstructorResult(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/go-mod-bootstrap
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-configuration v0.0.8
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.111
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.114
 	github.com/edgexfoundry/go-mod-registry v0.1.26
 	github.com/edgexfoundry/go-mod-secrets v0.0.26
 	github.com/gorilla/mux v1.7.1


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Initial Logging client created by boot-strap uses DEBUG level and can not be overridden. This client is used until configuration is loaded.

## Issue Number: #123


## What is the new behavior?
Service can now pass an initial Logging Client in the DIC for bootstrap to use instead of creating one.
This enables Security Utility to run in silent mode as initial client can be set to EROOR instead of DEBUG as it now.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information