### PR TITLE
fix: LoggingClientFrom handle nil case properly

### DIFF
--- a/bootstrap/container/logging.go
+++ b/bootstrap/container/logging.go
@@ -25,5 +25,9 @@ var LoggingClientInterfaceName = di.TypeInstanceToName((*logger.LoggingClient)(n
 
 // LoggingClientFrom helper function queries the DIC and returns the logger.loggingClient implementation.
 func LoggingClientFrom(get di.Get) logger.LoggingClient {
-	return get(LoggingClientInterfaceName).(logger.LoggingClient)
+	if loggingClient, ok := get(LoggingClientInterfaceName).(logger.LoggingClient); ok {
+		return loggingClient
+	} else {
+		return nil
+	}
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Commit 3651de7 revised bootstrap.go to DI get the logging client first as opposed to directly creating a Stdout logging client. However, the logic inside `LoggingClientFrom` doesn't deal with nil case and will result in `panic: interface conversion: interface is nil, not logger.LoggingClient`.

## Issue Number:
#128 

## What is the new behavior?
Deal with nil case inside `LoggingClientFrom` to avoid panic.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No
