### PR TITLE
refactor: Consume V2 Go Modules for edgex go-mods

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -31,10 +31,10 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
 // Deferred defines the signature of a function returned by RunAndReturnWaitGroup that should be executed via defer.

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -30,10 +30,10 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
-	"github.com/edgexfoundry/go-mod-configuration/configuration"
-	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
+	"github.com/edgexfoundry/go-mod-configuration/v2/configuration"
+	"github.com/edgexfoundry/go-mod-configuration/v2/pkg/types"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 
 	"github.com/BurntSushi/toml"
 )

--- a/bootstrap/config/provider.go
+++ b/bootstrap/config/provider.go
@@ -14,7 +14,7 @@
 package config
 
 import (
-	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
+	"github.com/edgexfoundry/go-mod-configuration/v2/pkg/types"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/environment"
 )

--- a/bootstrap/config/provider_test.go
+++ b/bootstrap/config/provider_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/environment"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 const (

--- a/bootstrap/container/logging.go
+++ b/bootstrap/container/logging.go
@@ -15,7 +15,7 @@
 package container
 
 import (
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 )

--- a/bootstrap/container/registry.go
+++ b/bootstrap/container/registry.go
@@ -17,7 +17,7 @@ package container
 import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 )
 
 // RegistryClientInterfaceName contains the name of the registry.Client implementation in the DIC.

--- a/bootstrap/container/token.go
+++ b/bootstrap/container/token.go
@@ -15,7 +15,7 @@
 package container
 
 import (
-	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/authtokenloader"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 )

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -22,10 +22,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/models"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 
-	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
+	"github.com/edgexfoundry/go-mod-configuration/v2/pkg/types"
 
 	"github.com/pelletier/go-toml"
 )

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -23,9 +23,9 @@ import (
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 
-	"github.com/edgexfoundry/go-mod-configuration/pkg/types"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	secretsTypes "github.com/edgexfoundry/go-mod-secrets/pkg/types"
+	"github.com/edgexfoundry/go-mod-configuration/v2/pkg/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	secretsTypes "github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/bootstrap/handlers/secret.go
+++ b/bootstrap/handlers/secret.go
@@ -25,11 +25,11 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-secrets/pkg/types"
-	"github.com/edgexfoundry/go-mod-secrets/secrets"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
+	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
 
-	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
-	"github.com/edgexfoundry/go-mod-secrets/pkg/token/fileioperformer"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/fileioperformer"
 )
 
 // SecureProviderBootstrapHandler full initializes the Secret Provider.

--- a/bootstrap/handlers/secret_test.go
+++ b/bootstrap/handlers/secret_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader/mocks"
-	"github.com/edgexfoundry/go-mod-secrets/pkg/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/authtokenloader/mocks"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -20,10 +20,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	registryTypes "github.com/edgexfoundry/go-mod-registry/pkg/types"
-	"github.com/edgexfoundry/go-mod-registry/registry"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	registryTypes "github.com/edgexfoundry/go-mod-registry/v2/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"

--- a/bootstrap/registration/registry_test.go
+++ b/bootstrap/registration/registry_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 // InsecureProvider implements the SecretProvider interface for insecure secrets

--- a/bootstrap/secret/insecure_test.go
+++ b/bootstrap/secret/insecure_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader"
-	"github.com/edgexfoundry/go-mod-secrets/secrets"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/authtokenloader"
+	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
 
 	"sync"
 	"time"

--- a/bootstrap/secret/secure_test.go
+++ b/bootstrap/secret/secure_test.go
@@ -20,11 +20,11 @@ import (
 	"time"
 
 	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v2/config"
-	"github.com/edgexfoundry/go-mod-core-contracts/clients/logger"
-	"github.com/edgexfoundry/go-mod-secrets/pkg"
-	mocks2 "github.com/edgexfoundry/go-mod-secrets/pkg/token/authtokenloader/mocks"
-	"github.com/edgexfoundry/go-mod-secrets/secrets"
-	"github.com/edgexfoundry/go-mod-secrets/secrets/mocks"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg"
+	mocks2 "github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/authtokenloader/mocks"
+	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
+	"github.com/edgexfoundry/go-mod-secrets/v2/secrets/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/config/types.go
+++ b/config/types.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/clients"
-	"github.com/edgexfoundry/go-mod-secrets/pkg/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
+	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 )
 
 // ServiceInfo contains configuration settings necessary for the basic operation of any EdgeX service.

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/edgexfoundry/go-mod-bootstrap/v2
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/edgexfoundry/go-mod-configuration v0.0.8
-	github.com/edgexfoundry/go-mod-core-contracts v0.1.147
-	github.com/edgexfoundry/go-mod-registry v0.1.27
-	github.com/edgexfoundry/go-mod-secrets v0.0.32
+	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.1
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.1
+	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.1
+	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.2
 	github.com/gorilla/mux v1.7.1
 	github.com/pelletier/go-toml v1.2.0
 	github.com/stretchr/testify v1.6.1


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Consuming V0 Go module versions for the edgeX go-mods

## Issue Number: #154


## What is the new behavior?
Consumes V2 Go module versions for the edgeX go-mods


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information