### PR TITLE
feat(v2): Create Helper functions to retrieve client library instances through DIC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/go-mod-bootstrap/v2
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.1
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.1
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.6
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.1
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.2
 	github.com/gorilla/mux v1.7.1

--- a/v2/bootstrap/container/common.go
+++ b/v2/bootstrap/container/common.go
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	v2Clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+)
+
+// CommonClientName contains the name of the CommonClient instance in the DIC.
+var CommonClientName = "V2CommonClient"
+
+// CommonClientFrom helper function queries the DIC and returns the CommonClient instance.
+func CommonClientFrom(get di.Get) v2Clients.CommonClient {
+	return get(CommonClientName).(v2Clients.CommonClient)
+}

--- a/v2/bootstrap/container/data.go
+++ b/v2/bootstrap/container/data.go
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	v2Clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+)
+
+// DataEventClientName contains the name of the EventClient instance in the DIC.
+var DataEventClientName = "V2DataEventClient"
+
+// DataReadingClientName contains the name of the ReadingClient instance in the DIC.
+var DataReadingClientName = "V2DataReadingClient"
+
+// DataEventClientFrom helper function queries the DIC and returns the EventClient instance.
+func DataEventClientFrom(get di.Get) v2Clients.EventClient {
+	return get(DataEventClientName).(v2Clients.EventClient)
+}
+
+// DataReadingClientFrom helper function queries the DIC and returns the ReadingClient instance.
+func DataReadingClientFrom(get di.Get) v2Clients.ReadingClient {
+	return get(DataReadingClientName).(v2Clients.ReadingClient)
+}

--- a/v2/bootstrap/container/deviceservice.go
+++ b/v2/bootstrap/container/deviceservice.go
@@ -1,0 +1,19 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	v2Clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+)
+
+// DeviceServiceCallbackClientName contains the name of the DeviceServiceCallbackClient instance in the DIC.
+var DeviceServiceCallbackClientName = "V2DeviceServiceCallbackClient"
+
+// DeviceServiceCallbackClientFrom helper function queries the DIC and returns the DeviceServiceCallbackClientFrom instance.
+func DeviceServiceCallbackClientFrom(get di.Get) v2Clients.DeviceServiceCallbackClient {
+	return get(DeviceServiceCallbackClientName).(v2Clients.DeviceServiceCallbackClient)
+}

--- a/v2/bootstrap/container/metadata.go
+++ b/v2/bootstrap/container/metadata.go
@@ -1,0 +1,43 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+	v2Clients "github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+)
+
+// MetadataDeviceClientName contains the name of the Metadata DeviceClient instance in the DIC.
+var MetadataDeviceClientName = "V2MetadataDeviceClient"
+
+// MetadataDeviceProfileClientName contains the name of the Metadata DeviceProfileClient instance in the DIC.
+var MetadataDeviceProfileClientName = "V2MetadataDeviceProfileClient"
+
+// MetadataDeviceServiceClientName contains the name of the Metadata DeviceServiceClient instance in the DIC.
+var MetadataDeviceServiceClientName = "V2MetadataDeviceServiceClient"
+
+// MetadataProvisionWatcherClientName contains the name of the Metadata ProvisionWatcherClient instance in the DIC.
+var MetadataProvisionWatcherClientName = "V2MetadataProvisionWatcherClient"
+
+// MetadataDeviceClientFrom helper function queries the DIC and returns the Metadata DeviceClient instance.
+func MetadataDeviceClientFrom(get di.Get) v2Clients.DeviceClient {
+	return get(MetadataDeviceClientName).(v2Clients.DeviceClient)
+}
+
+// MetadataDeviceProfileClientFrom helper function queries the DIC and returns the Metadata DeviceProfileClient instance.
+func MetadataDeviceProfileClientFrom(get di.Get) v2Clients.DeviceProfileClient {
+	return get(MetadataDeviceProfileClientName).(v2Clients.DeviceProfileClient)
+}
+
+// MetadataDeviceServiceClientFrom helper function queries the DIC and returns the Metadata DeviceServiceClient instance.
+func MetadataDeviceServiceClientFrom(get di.Get) v2Clients.DeviceServiceClient {
+	return get(MetadataDeviceServiceClientName).(v2Clients.DeviceServiceClient)
+}
+
+// MetadataProvisionWatcherClientFrom helper function queries the DIC and returns the Metadata ProvisionWatcherClient instance.
+func MetadataProvisionWatcherClientFrom(get di.Get) v2Clients.ProvisionWatcherClient {
+	return get(MetadataProvisionWatcherClientName).(v2Clients.ProvisionWatcherClient)
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #157 

## What is the new behavior?
For V2 APIs, each services will interact with other services through client libraries as defined in https://github.com/edgexfoundry/go-mod-core-contracts/tree/master/v2/clients, and each services will create their own helper functions to query DIC and get client instances. These helper functions could actually be shared among each services. Per suggestion from [community](https://github.com/edgexfoundry/edgex-go/pull/3061#discussion_r562162005), this PR creates these helper functions into go-mod-bootstrap.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No