### PR TITLE
feat(v2): Add helper to query DIC and returns the DeviceServiceCommandClient instance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgexfoundry/go-mod-bootstrap/v2
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.1
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.13
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.18
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.1
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.3
 	github.com/gorilla/mux v1.7.1

--- a/v2/bootstrap/container/deviceservice.go
+++ b/v2/bootstrap/container/deviceservice.go
@@ -13,9 +13,22 @@ import (
 // DeviceServiceCallbackClientName contains the name of the DeviceServiceCallbackClient instance in the DIC.
 var DeviceServiceCallbackClientName = di.TypeInstanceToName((*interfaces.DeviceServiceCallbackClient)(nil))
 
-// DeviceServiceCallbackClientFrom helper function queries the DIC and returns the DeviceServiceCallbackClientFrom instance.
+// DeviceServiceCommandClientName contains the name of the DeviceServiceCommandClient instance in the DIC.
+var DeviceServiceCommandClientName = di.TypeInstanceToName((*interfaces.DeviceServiceCommandClient)(nil))
+
+// DeviceServiceCallbackClientFrom helper function queries the DIC and returns the DeviceServiceCallbackClient instance.
 func DeviceServiceCallbackClientFrom(get di.Get) interfaces.DeviceServiceCallbackClient {
 	client, ok := get(DeviceServiceCallbackClientName).(interfaces.DeviceServiceCallbackClient)
+	if !ok {
+		return nil
+	}
+
+	return client
+}
+
+// DeviceServiceCommandClientFrom helper function queries the DIC and returns the DeviceServiceCommandClient instance.
+func DeviceServiceCommandClientFrom(get di.Get) interfaces.DeviceServiceCommandClient {
+	client, ok := get(DeviceServiceCommandClientName).(interfaces.DeviceServiceCommandClient)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION


Signed-off-by: Jude Hung <jude@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:
fix #161 

## What is the new behavior?
DeviceServiceCommandClient was added into go-mod-core-contracts, and we shall have corresponding helper function in go-mod-bootstrap to query DIC and then return the DeviceServiceCommandClient instance

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No