### PR TITLE
feat: Add config client in DIC

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -135,6 +135,12 @@ func (cp *Processor) Process(serviceKey string, configStem string, serviceConfig
 
 		cp.listenForChanges(serviceConfig, configClient)
 
+		cp.dic.Update(di.ServiceConstructorMap{
+			container.ConfigClientInterfaceName: func(get di.Get) interface{} {
+				return configClient
+			},
+		})
+
 	case false:
 		cp.logConfigInfo("Using local configuration from file", overrideCount)
 	}

--- a/bootstrap/container/configuration.go
+++ b/bootstrap/container/configuration.go
@@ -15,6 +15,8 @@
 package container
 
 import (
+	"github.com/edgexfoundry/go-mod-configuration/v2/configuration"
+
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 )
@@ -30,4 +32,17 @@ func ConfigurationFrom(get di.Get) interfaces.Configuration {
 	}
 
 	return configuration
+}
+
+// ConfigClientInterfaceName contains the name of the configuration.Client implementation in the DIC.
+var ConfigClientInterfaceName = di.TypeInstanceToName((*configuration.Client)(nil))
+
+// ConfigClientFrom helper function queries the DIC and returns the configuration.Client implementation.
+func ConfigClientFrom(get di.Get) configuration.Client {
+	client, ok := get(ConfigClientInterfaceName).(configuration.Client)
+	if !ok {
+		return nil
+	}
+
+	return client
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Reference to the configuration client is not in the DIC.

## Issue Number: closes #177


## What is the new behavior?
Reference to the configuration client is now in the DIC where App Services can use it for custom config.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information