### PR TITLE
fix: Use /api/v2/ping for Registry healthchecks

### DIFF
--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	registryTypes "github.com/edgexfoundry/go-mod-registry/v2/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 
@@ -59,7 +59,7 @@ func createRegistryClient(
 		ServicePort:     bootstrapConfig.Service.Port,
 		ServiceProtocol: bootstrapConfig.Service.Protocol,
 		CheckInterval:   bootstrapConfig.Service.CheckInterval,
-		CheckRoute:      clients.ApiPingRoute,
+		CheckRoute:      v2.ApiPingRoute,
 	}
 
 	lc.Info(fmt.Sprintf("Using Registry (%s) from %s", registryConfig.Type, registryConfig.GetRegistryUrl()))


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Health checks still using `api/v1/ping`

## Issue Number: #188


## What is the new behavior?
Health checks now using `api/v2/ping`


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information