### PR TITLE
refactor: Set the Config Version when creating Config Client

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sync"
 
@@ -40,7 +41,10 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-const writableKey = "/Writable"
+const (
+	writableKey   = "/Writable"
+	configVersion = "2.0"
+)
 
 // UpdatedStream defines the stream type that is notified by ListenForChanges when a configuration update is received.
 type UpdatedStream chan struct{}
@@ -312,7 +316,7 @@ func (cp *Processor) createProviderClient(
 	accessTokenFile string,
 	providerConfig types.ServiceConfig) (configuration.Client, error) {
 
-	providerConfig.BasePath = configStem + serviceKey
+	providerConfig.BasePath = filepath.Join(configStem, configVersion, serviceKey)
 	providerConfig.AccessToken = accessTokenFile
 
 	cp.Logger.Info(fmt.Sprintf(


### PR DESCRIPTION


closes #200

Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Config version set separately by Core/Support, App and Device services.

## Issue Number: #200


## What is the new behavior?
This centralizes the config version for all Go services.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No

BREAKING CHANGE: Configuration in Consul now under the `/2.0/` path

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information