### PR TITLE
refactor: Replace use of BurntSushi/toml with pelletier/go-toml

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/edgexfoundry/go-mod-bootstrap/v2
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.5
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Unmaintained module `BurntSushi/toml` is used to un-marshal TOML file

## Issue Number: #208


## What is the new behavior?
pelletier/go-toml module is now used to un-marshal TOML file

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information