### PR TITLE
refactor: update calling GenerateConsulToken

### DIFF
--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -163,7 +163,7 @@ func (p *SecureProvider) SecretsLastUpdated() time.Time {
 func (p *SecureProvider) GetAccessToken(tokenType string, serviceKey string) (string, error) {
 	switch tokenType {
 	case TokenTypeConsul:
-		return p.secretClient.GenerateConsulToken("", serviceKey)
+		return p.secretClient.GenerateConsulToken(serviceKey)
 	default:
 		return "", fmt.Errorf("invalid access token type '%s'", tokenType)
 	}

--- a/bootstrap/secret/secure_test.go
+++ b/bootstrap/secret/secure_test.go
@@ -224,7 +224,7 @@ func TestSecureProvider_GetAccessToken(t *testing.T) {
 	testServiceKey := "edgex-unit-test"
 	expectedToken := "myAccessToken"
 	mock := &mocks.SecretClient{}
-	mock.On("GenerateConsulToken", "", testServiceKey).Return(expectedToken, nil)
+	mock.On("GenerateConsulToken", testServiceKey).Return(expectedToken, nil)
 
 	tests := []struct {
 		name        string

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.5
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.4
-	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.14
+	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.15
 	github.com/gorilla/mux v1.7.1
 	github.com/pelletier/go-toml v1.9.0
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
the API for calling GenerateConsulToken has changed from go-mod-secret and thus requires a change

Fixes: #211
Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
interface changed

## Issue Number: #211 


## What is the new behavior?
updated according to interface change

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information