### PR TITLE
fix: Fix Secure MessageBus Secret validation for non-secure mode

### DIFF
--- a/bootstrap/messaging/messaging.go
+++ b/bootstrap/messaging/messaging.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
@@ -205,7 +206,7 @@ func GetSecretData(authMode string, secretName string, provider SecretDataProvid
 func ValidateSecretData(authMode string, secretName string, secretData *SecretData) error {
 	switch authMode {
 	case AuthModeUsernamePassword:
-		if secretData.Username == "" || secretData.Password == "" {
+		if secret.IsSecurityEnabled() && (secretData.Username == "" || secretData.Password == "") {
 			return fmt.Errorf("AuthModeUsernamePassword selected however Username or Password was not found for secret=%s", secretName)
 		}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
username & password **can not** be blank in non-secure mode.


## Issue Number:  #232


## What is the new behavior?
username & password **can now** be blank in non-secure mode.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information