### PR TITLE
refactor: Update ServiceInfo struct to be used by all services and add MaxRequestSize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 GO=CGO_ENABLED=0 GO111MODULE=on go
 
 test:
+	go mod tidy
 	$(GO) test ./... -coverprofile=coverage.out ./...
 	$(GO) vet ./...
 	gofmt -l .

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -88,7 +88,8 @@ func (b *HttpServer) BootstrapHandler(
 		addr = bootstrapConfig.Service.Host + ":" + port
 	}
 
-	timeout := time.Millisecond * time.Duration(bootstrapConfig.Service.Timeout)
+	timeout, err := time.ParseDuration(bootstrapConfig.Service.RequestTimeout)
+	lc.Errorf("unable to parse RequestTimeout value of %s to a duration: %w", bootstrapConfig.Service.RequestTimeout, err)
 	server := &http.Server{
 		Addr:         addr,
 		Handler:      b.router,

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	registryTypes "github.com/edgexfoundry/go-mod-registry/v2/pkg/types"
@@ -64,8 +65,8 @@ func createRegistryClient(
 		ServiceKey:      serviceKey,
 		ServiceHost:     bootstrapConfig.Service.Host,
 		ServicePort:     bootstrapConfig.Service.Port,
-		ServiceProtocol: bootstrapConfig.Service.Protocol,
-		CheckInterval:   bootstrapConfig.Service.CheckInterval,
+		ServiceProtocol: config.DefaultHttpProtocol,
+		CheckInterval:   bootstrapConfig.Service.HealthCheckInterval,
 		CheckRoute:      v2.ApiPingRoute,
 	}
 

--- a/bootstrap/registration/registry_test.go
+++ b/bootstrap/registration/registry_test.go
@@ -34,9 +34,8 @@ func TestCreateRegistryClient(t *testing.T) {
 
 	serviceConfig := unitTestConfiguration{
 		Service: config.ServiceInfo{
-			Host:     "localhost",
-			Port:     8080,
-			Protocol: "http",
+			Host: "localhost",
+			Port: 8080,
 		},
 		Registry: config.RegistryInfo{
 			Host: "localhost",

--- a/config/types.go
+++ b/config/types.go
@@ -23,13 +23,12 @@ import (
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 )
 
+const DefaultHttpProtocol = "http"
+
 // ServiceInfo contains configuration settings necessary for the basic operation of any EdgeX service.
 type ServiceInfo struct {
-	// BootTimeout indicates, in milliseconds, how long the service will retry connecting to upstream dependencies
-	// before giving up. Default is 30,000.
-	BootTimeout int
-	// Health check interval
-	CheckInterval string
+	// HealthCheckInterval is the interval for Registry heal check callback
+	HealthCheckInterval string
 	// Host is the hostname or IP address of the service.
 	Host string
 	// Port is the HTTP port of the service.
@@ -37,30 +36,30 @@ type ServiceInfo struct {
 	// ServerBindAddr specifies an IP address or hostname
 	// for ListenAndServe to bind to, such as 0.0.0.0
 	ServerBindAddr string
-	// The protocol that should be used to call this service
-	Protocol string
 	// StartupMsg specifies a string to log once service
 	// initialization and startup is completed.
 	StartupMsg string
 	// MaxResultCount specifies the maximum size list supported
 	// in response to REST calls to other services.
 	MaxResultCount int
-	// Timeout specifies a timeout (in milliseconds) for
-	// processing REST calls from other services.
-	Timeout int
+	// MaxRequestSize defines the maximum size of http request body in bytes
+	MaxRequestSize int64
+	// RequestTimeout specifies a timeout (in milliseconds) for
+	// processing REST request calls from other services.
+	RequestTimeout string
 }
 
 // HealthCheck is a URL specifying a health check REST endpoint used by the Registry to determine if the
 // service is available.
 func (s ServiceInfo) HealthCheck() string {
-	hc := fmt.Sprintf("%s://%s:%v%s", s.Protocol, s.Host, s.Port, v2.ApiPingRoute)
+	hc := fmt.Sprintf("%s://%s:%v%s", "http", s.Host, s.Port, v2.ApiPingRoute)
 	return hc
 }
 
 // Url provides a way to obtain the full url of the host service for use in initialization or, in some cases,
 // responses to a caller.
 func (s ServiceInfo) Url() string {
-	url := fmt.Sprintf("%s://%s:%v", s.Protocol, s.Host, s.Port)
+	url := fmt.Sprintf("%s://%s:%v", DefaultHttpProtocol, s.Host, s.Port)
 	return url
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
ServiceInfo struct not used directly by all the services. Some field names a bit ambiguous 

## Issue Number: #130 & #241

## What is the new behavior?
ServiceInfo struct not usable by all the services with better names for some fields. 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Service configuration has changed for all services

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information