### PR TITLE
fix(secuirty): Remove retry config items from SecretStore config

### DIFF
--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -103,17 +103,15 @@ func NewSecretProvider(
 // If a token file is present it will override the Authentication.AuthToken value.
 func getSecretConfig(secretStoreInfo config.SecretStoreInfo, tokenLoader authtokenloader.AuthTokenLoader) (types.SecretConfig, error) {
 	secretConfig := types.SecretConfig{
-		Type:                    secretStoreInfo.Type, // Type of SecretStore implementation, i.e. Vault
-		Host:                    secretStoreInfo.Host,
-		Port:                    secretStoreInfo.Port,
-		Path:                    addEdgeXSecretPathPrefix(secretStoreInfo.Path),
-		Protocol:                secretStoreInfo.Protocol,
-		Namespace:               secretStoreInfo.Namespace,
-		RootCaCertPath:          secretStoreInfo.RootCaCertPath,
-		ServerName:              secretStoreInfo.ServerName,
-		Authentication:          secretStoreInfo.Authentication,
-		AdditionalRetryAttempts: secretStoreInfo.AdditionalRetryAttempts,
-		RetryWaitPeriod:         secretStoreInfo.RetryWaitPeriod,
+		Type:           secretStoreInfo.Type, // Type of SecretStore implementation, i.e. Vault
+		Host:           secretStoreInfo.Host,
+		Port:           secretStoreInfo.Port,
+		Path:           addEdgeXSecretPathPrefix(secretStoreInfo.Path),
+		Protocol:       secretStoreInfo.Protocol,
+		Namespace:      secretStoreInfo.Namespace,
+		RootCaCertPath: secretStoreInfo.RootCaCertPath,
+		ServerName:     secretStoreInfo.ServerName,
+		Authentication: secretStoreInfo.Authentication,
 	}
 
 	if !IsSecurityEnabled() || secretStoreInfo.TokenFile == "" {

--- a/config/types.go
+++ b/config/types.go
@@ -17,7 +17,6 @@ package config
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
@@ -97,18 +96,15 @@ func (c ClientInfo) Url() string {
 
 // SecretStoreInfo encapsulates configuration properties used to create a SecretClient.
 type SecretStoreInfo struct {
-	Type                    string
-	Host                    string
-	Port                    int
-	Path                    string
-	Protocol                string
-	Namespace               string
-	RootCaCertPath          string
-	ServerName              string
-	Authentication          types.AuthenticationInfo
-	AdditionalRetryAttempts int
-	RetryWaitPeriod         string
-	retryWaitPeriodTime     time.Duration
+	Type           string
+	Host           string
+	Port           int
+	Path           string
+	Protocol       string
+	Namespace      string
+	RootCaCertPath string
+	ServerName     string
+	Authentication types.AuthenticationInfo
 	// TokenFile provides a location to a token file.
 	TokenFile string
 }

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/edgexfoundry/go-mod-bootstrap/v2
 
 require (
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.89
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
-	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.21
+	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.23
 	github.com/gorilla/mux v1.7.4
 	github.com/pelletier/go-toml v1.9.1
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Once retry cleanup code is used, the related configuration items of `AdditionalRetryAttempts`, `RetryWaitPeriod`, and `RetryWaitPeriodTime` for `SecretStore` config struct needs to be removed too.

Fixes: #247

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Retry properties still in SecretStore config

## Issue Number:  #247 


## What is the new behavior?
Retry properties in SecretStore config struct got removed.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x ] Yes
- [ ] No

The caller or the client side uses this module will need to clean up these items `AdditionalRetryAttempts`, `RetryWaitPeriod`, and `RetryWaitPeriodTime` in `SecretStore` correspondingly.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information

In draft mode until we have a new tag number from `go-mod-secret` in CI pipeline.
