### PR TITLE
refactor!: Add internal prefix for secret path on SecretStore config

### DIFF
--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -1,5 +1,6 @@
 /********************************************************************************
  *  Copyright 2019 Dell Inc.
+ *  Copyright 2021 Intel Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +18,8 @@ package secret
 import (
 	"context"
 	"fmt"
+	"path"
+	"strings"
 
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
@@ -103,7 +106,7 @@ func getSecretConfig(secretStoreInfo config.SecretStoreInfo, tokenLoader authtok
 		Type:                    secretStoreInfo.Type, // Type of SecretStore implementation, i.e. Vault
 		Host:                    secretStoreInfo.Host,
 		Port:                    secretStoreInfo.Port,
-		Path:                    secretStoreInfo.Path,
+		Path:                    addEdgeXSecretPathPrefix(secretStoreInfo.Path),
 		Protocol:                secretStoreInfo.Protocol,
 		Namespace:               secretStoreInfo.Namespace,
 		RootCaCertPath:          secretStoreInfo.RootCaCertPath,
@@ -124,4 +127,15 @@ func getSecretConfig(secretStoreInfo config.SecretStoreInfo, tokenLoader authtok
 
 	secretConfig.Authentication.AuthToken = token
 	return secretConfig, nil
+}
+
+func addEdgeXSecretPathPrefix(secretPath string) string {
+	trimmedSecretPath := strings.TrimSpace(secretPath)
+
+	// in this case, treat it as no secret path
+	if len(trimmedSecretPath) == 0 {
+		return ""
+	}
+
+	return "/" + path.Join("v1", "secret", "edgex", trimmedSecretPath) + "/"
 }

--- a/bootstrap/secret/secret_test.go
+++ b/bootstrap/secret/secret_test.go
@@ -177,3 +177,24 @@ func (t TestConfig) GetRegistryInfo() bootstrapConfig.RegistryInfo {
 func (t TestConfig) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
 	return t.InsecureSecrets
 }
+
+func TestAddPrefix(t *testing.T) {
+	expectedPrefixPath := "/v1/secret/edgex/"
+
+	tests := []struct {
+		name             string
+		secretPath       string
+		expectedFullPath string
+	}{
+		{"non-empty given secret path without trailing slash", "core-command", expectedPrefixPath + "core-command/"},
+		{"non-empty given secret path with trailing slash", "core-command/", expectedPrefixPath + "core-command/"},
+		{"empty given secret path", "", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualSecretFullPath := addEdgeXSecretPathPrefix(test.secretPath)
+			require.Equal(t, test.expectedFullPath, actualSecretFullPath)
+		})
+	}
+}


### PR DESCRIPTION
Add internal prefix `/v1/secret/edgex/` for secret's Path in `SecretStore` config so that now we only need to specify the service specific secret path instead of the full path with /v1/secret/edgex/ + serviceSecrets

Closes: #249

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Currently the `Path` specified in the `SecretStore` config is full path with /v1/secret/edgex/ prefixed in all services using secret store.

## Issue Number: #249 


## What is the new behavior?
The fixed prefix `/v1/secret/edgex/` now is added and prefixed in the code implementation and now for every service just needs to specify the service specific secret path.


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x ] Yes
- [ ] No

**Note: this change will impact all services using SecretStore config and thus require changes in toml files.**

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x ] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information