### PR TITLE
refactor: Update to latest Core Contracts and remove v2 package

### DIFF
--- a/bootstrap/container/common.go
+++ b/bootstrap/container/common.go
@@ -7,7 +7,7 @@ package container
 
 import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
 )
 
 // CommonClientName contains the name of the CommonClient instance in the DIC.

--- a/bootstrap/container/data.go
+++ b/bootstrap/container/data.go
@@ -7,7 +7,7 @@ package container
 
 import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
 )
 
 // DataEventClientName contains the name of the EventClient instance in the DIC.

--- a/bootstrap/container/deviceservice.go
+++ b/bootstrap/container/deviceservice.go
@@ -7,7 +7,7 @@ package container
 
 import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
 )
 
 // DeviceServiceCallbackClientName contains the name of the DeviceServiceCallbackClient instance in the DIC.

--- a/bootstrap/container/metadata.go
+++ b/bootstrap/container/metadata.go
@@ -7,7 +7,7 @@ package container
 
 import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2/clients/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
 )
 
 // MetadataDeviceClientName contains the name of the Metadata DeviceClient instance in the DIC.

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	registryTypes "github.com/edgexfoundry/go-mod-registry/v2/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/v2/registry"
 
@@ -67,7 +67,7 @@ func createRegistryClient(
 		ServicePort:     bootstrapConfig.Service.Port,
 		ServiceProtocol: config.DefaultHttpProtocol,
 		CheckInterval:   bootstrapConfig.Service.HealthCheckInterval,
-		CheckRoute:      v2.ApiPingRoute,
+		CheckRoute:      common.ApiPingRoute,
 	}
 
 	lc.Info(fmt.Sprintf("Using Registry (%s) from %s", registryConfig.Type, registryConfig.GetRegistryUrl()))

--- a/config/types.go
+++ b/config/types.go
@@ -18,7 +18,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/v2"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 )
 
@@ -51,7 +51,7 @@ type ServiceInfo struct {
 // HealthCheck is a URL specifying a health check REST endpoint used by the Registry to determine if the
 // service is available.
 func (s ServiceInfo) HealthCheck() string {
-	hc := fmt.Sprintf("%s://%s:%v%s", "http", s.Host, s.Port, v2.ApiPingRoute)
+	hc := fmt.Sprintf("%s://%s:%v%s", "http", s.Host, s.Port, common.ApiPingRoute)
 	return hc
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/edgexfoundry/go-mod-bootstrap/v2
 
 require (
-	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.8
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.98
+	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0-dev.9
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.100
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0-dev.7
-	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.23
+	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0-dev.25
 	github.com/gorilla/mux v1.7.4
 	github.com/pelletier/go-toml v1.9.2
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Files under v2 package moved to existing `container` package

closes 


- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Using old versions of go-mods which Core Contracts that has `v1` code and `v2` code under the `v2` package

## Issue Number: #255


## What is the new behavior?
Using latest versions of go-mods which Core Contracts that has no `v2` package or old `v1` code

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information