### PR TITLE
fix: Use correct name when logging EDGEX_CONF_DIR override

### DIFF
--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -297,7 +297,7 @@ func GetConfDir(lc logger.LoggingClient, configDir string) string {
 	envValue := os.Getenv(envConfDir)
 	if len(envValue) > 0 {
 		configDir = envValue
-		logEnvironmentOverride(lc, "-c/-confdir", envFile, envValue)
+		logEnvironmentOverride(lc, "-c/-confdir", envConfDir, envValue)
 	}
 
 	if len(configDir) == 0 {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/master/.github/Contributing.md.

## What is the current behavior?
Logging for EDGEX_CONF_DIR override uses incorrect name `envFile`

## Issue Number: #264


## What is the new behavior?
Logging for EDGEX_CONF_DIR override uses correct name `envConfDir`


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information