### PR TITLE
feat: Add optional capability to seed service secrets

### DIFF
--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -76,7 +76,7 @@ func NewSecretProvider(
 					lc.Debugf("SecretsFile is '%s'", secretConfig.SecretsFile)
 
 					if len(strings.TrimSpace(secretConfig.SecretsFile)) > 0 {
-						err = secureProvider.LoadServiceSecrets(secretStoreConfig.SecretsFile, secretStoreConfig.DisableScrubSecretsFile)
+						err = secureProvider.LoadServiceSecrets(secretStoreConfig)
 						if err != nil {
 							return nil, err
 						}

--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -72,6 +72,18 @@ func NewSecretProvider(
 				secretClient, err = secrets.NewSecretsClient(ctx, secretConfig, lc, secureProvider.DefaultTokenExpiredCallback)
 				if err == nil {
 					secureProvider.SetClient(secretClient)
+
+					lc.Infof("SecretsFile is '%s'", secretConfig.SecretsFile)
+
+					if len(strings.TrimSpace(secretConfig.SecretsFile)) > 0 {
+						err = secureProvider.LoadServiceSecrets(secretConfig.SecretsFile)
+						if err != nil {
+							return nil, err
+						}
+					} else {
+						lc.Infof("SecretsFile not set, skipping seeding of service secrets.")
+					}
+
 					provider = secureProvider
 					lc.Info("Created SecretClient")
 					break
@@ -107,6 +119,7 @@ func getSecretConfig(secretStoreInfo config.SecretStoreInfo, tokenLoader authtok
 		Host:           secretStoreInfo.Host,
 		Port:           secretStoreInfo.Port,
 		Path:           addEdgeXSecretPathPrefix(secretStoreInfo.Path),
+		SecretsFile:    secretStoreInfo.SecretsFile,
 		Protocol:       secretStoreInfo.Protocol,
 		Namespace:      secretStoreInfo.Namespace,
 		RootCaCertPath: secretStoreInfo.RootCaCertPath,

--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -72,20 +72,20 @@ func NewSecretProvider(
 				secretClient, err = secrets.NewSecretsClient(ctx, secretConfig, lc, secureProvider.DefaultTokenExpiredCallback)
 				if err == nil {
 					secureProvider.SetClient(secretClient)
+					provider = secureProvider
+					lc.Info("Created SecretClient")
 
 					lc.Debugf("SecretsFile is '%s'", secretConfig.SecretsFile)
 
-					if len(strings.TrimSpace(secretConfig.SecretsFile)) > 0 {
-						err = secureProvider.LoadServiceSecrets(secretStoreConfig)
-						if err != nil {
-							return nil, err
-						}
-					} else {
+					if len(strings.TrimSpace(secretConfig.SecretsFile)) == 0 {
 						lc.Infof("SecretsFile not set, skipping seeding of service secrets.")
+						break
 					}
 
-					provider = secureProvider
-					lc.Info("Created SecretClient")
+					err = secureProvider.LoadServiceSecrets(secretStoreConfig)
+					if err != nil {
+						return nil, err
+					}
 					break
 				}
 			}

--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -76,7 +76,7 @@ func NewSecretProvider(
 					lc.Debugf("SecretsFile is '%s'", secretConfig.SecretsFile)
 
 					if len(strings.TrimSpace(secretConfig.SecretsFile)) > 0 {
-						err = secureProvider.LoadServiceSecrets(secretConfig.SecretsFile)
+						err = secureProvider.LoadServiceSecrets(secretStoreConfig.SecretsFile, secretStoreConfig.DisableScrubSecretsFile)
 						if err != nil {
 							return nil, err
 						}

--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -73,7 +73,7 @@ func NewSecretProvider(
 				if err == nil {
 					secureProvider.SetClient(secretClient)
 
-					lc.Infof("SecretsFile is '%s'", secretConfig.SecretsFile)
+					lc.Debugf("SecretsFile is '%s'", secretConfig.SecretsFile)
 
 					if len(strings.TrimSpace(secretConfig.SecretsFile)) > 0 {
 						err = secureProvider.LoadServiceSecrets(secretConfig.SecretsFile)

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -197,6 +197,7 @@ func (p *SecureProvider) DefaultTokenExpiredCallback(expiredToken string) (repla
 	return reReadToken, true
 }
 
+// LoadServiceSecrets loads the service secrets from the specified file and stores them in the service's SecretStore
 func (p *SecureProvider) LoadServiceSecrets(filePath string) error {
 	contents, err := os.ReadFile(filePath)
 	if err != nil {

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -198,7 +198,7 @@ func (p *SecureProvider) DefaultTokenExpiredCallback(expiredToken string) (repla
 }
 
 // LoadServiceSecrets loads the service secrets from the specified file and stores them in the service's SecretStore
-func (p *SecureProvider) LoadServiceSecrets(filePath string) error {
+func (p *SecureProvider) LoadServiceSecrets(filePath string, scrubDisabled bool) error {
 	contents, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("seeding secrets failed: %s", err.Error())
@@ -206,9 +206,16 @@ func (p *SecureProvider) LoadServiceSecrets(filePath string) error {
 
 	data, seedingErrs := p.seedSecrets(contents)
 
+	if scrubDisabled {
+		p.lc.Infof("Scrubbing of secrets file disable.")
+		return seedingErrs
+	}
+
 	if err := os.WriteFile(filePath, data, 0); err != nil {
 		return fmt.Errorf("seeding secrets failed: unable to overwrite file with secret data removed: %s", err.Error())
 	}
+
+	p.lc.Infof("Scrubbing of secrets file complete.")
 
 	return seedingErrs
 }

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 
@@ -198,20 +199,21 @@ func (p *SecureProvider) DefaultTokenExpiredCallback(expiredToken string) (repla
 }
 
 // LoadServiceSecrets loads the service secrets from the specified file and stores them in the service's SecretStore
-func (p *SecureProvider) LoadServiceSecrets(filePath string, scrubDisabled bool) error {
-	contents, err := os.ReadFile(filePath)
+func (p *SecureProvider) LoadServiceSecrets(secretStoreConfig config.SecretStoreInfo) error {
+
+	contents, err := os.ReadFile(secretStoreConfig.SecretsFile)
 	if err != nil {
 		return fmt.Errorf("seeding secrets failed: %s", err.Error())
 	}
 
 	data, seedingErrs := p.seedSecrets(contents)
 
-	if scrubDisabled {
+	if secretStoreConfig.DisableScrubSecretsFile {
 		p.lc.Infof("Scrubbing of secrets file disable.")
 		return seedingErrs
 	}
 
-	if err := os.WriteFile(filePath, data, 0); err != nil {
+	if err := os.WriteFile(secretStoreConfig.SecretsFile, data, 0); err != nil {
 		return fmt.Errorf("seeding secrets failed: unable to overwrite file with secret data removed: %s", err.Error())
 	}
 

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -18,12 +18,18 @@ package secret
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/token/authtokenloader"
 	"github.com/edgexfoundry/go-mod-secrets/v2/secrets"
 )
@@ -169,7 +175,7 @@ func (p *SecureProvider) GetAccessToken(tokenType string, serviceKey string) (st
 	}
 }
 
-// defaultTokenExpiredCallback is the default implementation of tokenExpiredCallback function
+// DefaultTokenExpiredCallback is the default implementation of tokenExpiredCallback function
 // It utilizes the tokenFile to re-read the token and enable retry if any update from the expired token
 func (p *SecureProvider) DefaultTokenExpiredCallback(expiredToken string) (replacementToken string, retry bool) {
 	tokenFile := p.configuration.GetBootstrap().SecretStore.TokenFile
@@ -189,4 +195,70 @@ func (p *SecureProvider) DefaultTokenExpiredCallback(expiredToken string) (repla
 	}
 
 	return reReadToken, true
+}
+
+func (p *SecureProvider) LoadServiceSecrets(filePath string) error {
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("seeding secrets failed: %s", err.Error())
+	}
+
+	data, seedingErrs := p.seedSecrets(contents)
+
+	if err := os.WriteFile(filePath, data, 0); err != nil {
+		return fmt.Errorf("seeding secrets failed: unable to overwrite file with secret data removed: %s", err.Error())
+	}
+
+	return seedingErrs
+}
+
+func (p *SecureProvider) seedSecrets(contents []byte) ([]byte, error) {
+	serviceSecrets, err := UnmarshalServiceSecretsJson(contents)
+	if err != nil {
+		return nil, fmt.Errorf("seeding secrets failed unmarshaling JSON: %s", err.Error())
+	}
+
+	p.lc.Infof("Seeding %d Service Secrets", len(serviceSecrets.Secrets))
+
+	var seedingErrs error
+	for index, secret := range serviceSecrets.Secrets {
+		if secret.Imported {
+			p.lc.Infof("Secret for '%s' already imported. Skipping...", secret.Path)
+			continue
+		}
+
+		// At this pint the JSON validation and above check cover all the required validation, so go to store secret.
+		path, data := prepareSecret(secret)
+		err := p.StoreSecret(path, data)
+		if err != nil {
+			message := fmt.Sprintf("failed to store secret for '%s': %s", secret.Path, err.Error())
+			p.lc.Errorf(message)
+			seedingErrs = multierror.Append(seedingErrs, errors.New(message))
+			continue
+		}
+
+		p.lc.Infof("Secret for '%s' successfully stored.", secret.Path)
+
+		serviceSecrets.Secrets[index].Imported = true
+		serviceSecrets.Secrets[index].SecretData = make([]common.SecretDataKeyValue, 0)
+	}
+
+	// Now need to write the file back over with the imported secrets' secretData removed.
+	data, err := serviceSecrets.MarshalJson()
+	if err != nil {
+		return nil, fmt.Errorf("seeding secrets failed marshaling back to JSON to clear secrets: %s", err.Error())
+	}
+
+	return data, seedingErrs
+}
+
+func prepareSecret(secret ServiceSecret) (string, map[string]string) {
+	var secretsKV = make(map[string]string)
+	for _, secret := range secret.SecretData {
+		secretsKV[secret.Key] = secret.Value
+	}
+
+	path := strings.TrimSpace(secret.Path)
+
+	return path, secretsKV
 }

--- a/bootstrap/secret/secure_test.go
+++ b/bootstrap/secret/secure_test.go
@@ -261,14 +261,14 @@ func TestSecureProvider_seedSecrets(t *testing.T) {
 	badJson := `{"secrets": [{"path": "","imported": false,"secretData": null}]}`
 
 	tests := []struct {
-		name        string
+		name          string
 		secretsJson   string
-		expectedJson string
-		mockError bool
+		expectedJson  string
+		mockError     bool
 		expectedError string
 	}{
-		{"Valid", allGood, allGoodExpected, false,""},
-		{"Partial Valid", allGood, allGoodExpected, false,""},
+		{"Valid", allGood, allGoodExpected, false, ""},
+		{"Partial Valid", allGood, allGoodExpected, false, ""},
 		{"Bad JSON", badJson, "", false, "seeding secrets failed unmarshaling JSON: ServiceSecrets.Secrets[0].Path field should not be empty string; ServiceSecrets.Secrets[0].SecretData field is required"},
 		{"Store Error", allGood, "", true, "1 error occurred:\n\t* failed to store secret for 'auth': store failed\n\n"},
 	}

--- a/bootstrap/secret/types.go
+++ b/bootstrap/secret/types.go
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package secret
+
+import (
+	"encoding/json"
+	"fmt"
+
+	validation "github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/hashicorp/go-multierror"
+)
+
+// ServiceSecrets contains the list of secrets to import into a service's SecretStore
+type ServiceSecrets struct {
+	Secrets []ServiceSecret `json:"secrets" validate:"required,gt=0,dive"`
+}
+
+// ServiceSecret contains the information about a service's secret to import into a service's SecretStore
+type ServiceSecret struct {
+	Path       string                      `json:"path" validate:"edgex-dto-none-empty-string"`
+	Imported   bool                        `json:"imported"`
+	SecretData []common.SecretDataKeyValue `json:"secretData" validate:"required,dive"`
+}
+
+// MarshalJson marshal the service's secrets to JSON.
+func (s *ServiceSecrets) MarshalJson() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// UnmarshalServiceSecretsJson un-marshals the JSON containing the services list of secrets
+func UnmarshalServiceSecretsJson(data []byte) (*ServiceSecrets, error) {
+	secrets := &ServiceSecrets{}
+
+	if err := json.Unmarshal(data, secrets); err != nil {
+		return nil, err
+	}
+
+	if err := validation.Validate(secrets); err != nil {
+		return nil, err
+	}
+
+	var validationErrs error
+
+	// Since secretData len validation can't be specified to only validate when Imported=false, we have to do it manually here
+	for _, secret := range secrets.Secrets{
+		if !secret.Imported && len(secret.SecretData) == 0 {
+			validationErrs = multierror.Append(validationErrs, fmt.Errorf("SecretData for '%s' must not be empty when Imported=false",secret.Path))
+		}
+	}
+
+	if validationErrs != nil {
+		return nil, validationErrs
+	}
+
+	return secrets, nil
+}
+

--- a/bootstrap/secret/types.go
+++ b/bootstrap/secret/types.go
@@ -55,9 +55,9 @@ func UnmarshalServiceSecretsJson(data []byte) (*ServiceSecrets, error) {
 	var validationErrs error
 
 	// Since secretData len validation can't be specified to only validate when Imported=false, we have to do it manually here
-	for _, secret := range secrets.Secrets{
+	for _, secret := range secrets.Secrets {
 		if !secret.Imported && len(secret.SecretData) == 0 {
-			validationErrs = multierror.Append(validationErrs, fmt.Errorf("SecretData for '%s' must not be empty when Imported=false",secret.Path))
+			validationErrs = multierror.Append(validationErrs, fmt.Errorf("SecretData for '%s' must not be empty when Imported=false", secret.Path))
 		}
 	}
 
@@ -67,4 +67,3 @@ func UnmarshalServiceSecretsJson(data []byte) (*ServiceSecrets, error) {
 
 	return secrets, nil
 }
-

--- a/bootstrap/secret/types_test.go
+++ b/bootstrap/secret/types_test.go
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright 2021 Intel Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package secret
+
+import (
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceSecrets_UnmarshalJson_Imported_false(t *testing.T) {
+	expected := ServiceSecrets{
+		[]ServiceSecret{
+			{
+				Path:       "credentials001",
+				Imported:   false,
+				SecretData: []common.SecretDataKeyValue{{
+					Key:   "user1",
+					Value: "password1",
+				}},
+			},
+			{
+				Path:       "credentials002",
+				Imported:   false,
+				SecretData: []common.SecretDataKeyValue{{
+					Key:   "user2",
+					Value: "password2",
+				}},
+			},
+		},
+	}
+
+	data := ` {
+    "secrets": [
+        {
+            "path": "credentials001",
+            "imported": false,
+            "secretData": [
+                {
+                    "key": "user1",
+                    "value": "password1"
+                }
+            ]
+        },
+        {
+            "path": "credentials002",
+            "imported": false,
+            "secretData": [
+                {
+                    "key": "user2",
+                    "value": "password2"
+                }
+            ]
+        }
+    ]
+}
+`
+
+	secrets, err := UnmarshalServiceSecretsJson([]byte(data))
+	require.NoError(t, err)
+	assert.Equal(t, expected, *secrets)
+}
+
+func TestServiceSecrets_UnmarshalJson_Imported_true(t *testing.T) {
+	expected := ServiceSecrets{
+		[]ServiceSecret{
+			{
+				Path:       "credentials001",
+				Imported:   true,
+				SecretData: make([]common.SecretDataKeyValue,0),
+			},
+			{
+				Path:       "credentials002",
+				Imported:   true,
+				SecretData: make([]common.SecretDataKeyValue, 0),
+			},
+		},
+	}
+
+	data := ` {
+    "secrets": [
+        {
+            "path": "credentials001",
+            "imported": true,
+            "secretData": []
+        },
+        {
+            "path": "credentials002",
+            "imported": true,
+            "secretData": []
+        }
+    ]
+}
+`
+
+	secrets, err := UnmarshalServiceSecretsJson([]byte(data))
+	require.NoError(t, err)
+	assert.Equal(t, expected, *secrets)
+}
+
+func TestServiceSecrets_UnmarshalJson_Failed_Validation(t *testing.T) {
+	allGood := `{"secrets": [{"path": "auth","imported": false,"secretData": [{"key": "user1","value": "password1"}]}]}`
+	noPath := `{"secrets": [{"path": "","imported": false,"secretData": [{"key": "user1","value": "password1"}]}]}`
+	noSecretData := `{"secrets": [{"path": "auth","imported": false}]}`
+	emptySecretData := `{"secrets": [{"path": "auth","imported": false, "secretData": []}]}`
+	missingKey := `{"secrets": [{"path": "auth","imported": false,"secretData": [{"value": "password1"}]}]}`
+	missingValue := `{"secrets": [{"path": "auth","imported": false,"secretData": [{"key": "user1"}]}]}`
+
+	tests := []struct {
+		name string
+		data string
+		expectedError string
+	}{
+		{"All good", allGood, ""},
+		{"Empty JSON", `{}`, "ServiceSecrets.Secrets field is required"},
+		{"No Secrets", `{"secrets": []}`, "ServiceSecrets.Secrets field should greater than 0"},
+		{"No Path", noPath, "ServiceSecrets.Secrets[0].Path field should not be empty string"},
+		{"No SecretData", noSecretData, "ServiceSecrets.Secrets[0].SecretData field is required"},
+		{"Empty SecretData", emptySecretData, "1 error occurred:\n\t* SecretData for 'auth' must not be empty when Imported=false\n\n"},
+		{"Missing Key", missingKey, "ServiceSecrets.Secrets[0].SecretData[0].Key field is required"},
+		{"Missing Value", missingValue, "ServiceSecrets.Secrets[0].SecretData[0].Value field is required"},
+	}
+
+
+	for _, test := range tests{
+		t.Run(test.name, func(t *testing.T) {
+			_, err := UnmarshalServiceSecretsJson([]byte(test.data))
+			if len(test.expectedError) == 0 {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			assert.EqualError(t, err, test.expectedError)
+		})
+	}
+
+}
+
+func TestServiceSecrets_MarshalJson(t *testing.T) {
+	expected := `{"secrets":[{"path":"credentials001","imported":true,"secretData":[]},{"path":"credentials002","imported":true,"secretData":[]}]}`
+	secrets := ServiceSecrets{
+		[]ServiceSecret{
+			{
+				Path:       "credentials001",
+				Imported:   true,
+				SecretData: make([]common.SecretDataKeyValue,0),
+			},
+			{
+				Path:       "credentials002",
+				SecretData: make([]common.SecretDataKeyValue,0),
+				Imported:   true,
+			},
+		},
+	}
+
+	data, err := secrets.MarshalJson()
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(data))
+}

--- a/bootstrap/secret/types_test.go
+++ b/bootstrap/secret/types_test.go
@@ -26,16 +26,16 @@ func TestServiceSecrets_UnmarshalJson_Imported_false(t *testing.T) {
 	expected := ServiceSecrets{
 		[]ServiceSecret{
 			{
-				Path:       "credentials001",
-				Imported:   false,
+				Path:     "credentials001",
+				Imported: false,
 				SecretData: []common.SecretDataKeyValue{{
 					Key:   "user1",
 					Value: "password1",
 				}},
 			},
 			{
-				Path:       "credentials002",
-				Imported:   false,
+				Path:     "credentials002",
+				Imported: false,
 				SecretData: []common.SecretDataKeyValue{{
 					Key:   "user2",
 					Value: "password2",
@@ -81,7 +81,7 @@ func TestServiceSecrets_UnmarshalJson_Imported_true(t *testing.T) {
 			{
 				Path:       "credentials001",
 				Imported:   true,
-				SecretData: make([]common.SecretDataKeyValue,0),
+				SecretData: make([]common.SecretDataKeyValue, 0),
 			},
 			{
 				Path:       "credentials002",
@@ -121,8 +121,8 @@ func TestServiceSecrets_UnmarshalJson_Failed_Validation(t *testing.T) {
 	missingValue := `{"secrets": [{"path": "auth","imported": false,"secretData": [{"key": "user1"}]}]}`
 
 	tests := []struct {
-		name string
-		data string
+		name          string
+		data          string
 		expectedError string
 	}{
 		{"All good", allGood, ""},
@@ -135,8 +135,7 @@ func TestServiceSecrets_UnmarshalJson_Failed_Validation(t *testing.T) {
 		{"Missing Value", missingValue, "ServiceSecrets.Secrets[0].SecretData[0].Value field is required"},
 	}
 
-
-	for _, test := range tests{
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := UnmarshalServiceSecretsJson([]byte(test.data))
 			if len(test.expectedError) == 0 {
@@ -158,11 +157,11 @@ func TestServiceSecrets_MarshalJson(t *testing.T) {
 			{
 				Path:       "credentials001",
 				Imported:   true,
-				SecretData: make([]common.SecretDataKeyValue,0),
+				SecretData: make([]common.SecretDataKeyValue, 0),
 			},
 			{
 				Path:       "credentials002",
-				SecretData: make([]common.SecretDataKeyValue,0),
+				SecretData: make([]common.SecretDataKeyValue, 0),
 				Imported:   true,
 			},
 		},

--- a/config/types.go
+++ b/config/types.go
@@ -108,8 +108,11 @@ type SecretStoreInfo struct {
 	Authentication types.AuthenticationInfo
 	// TokenFile provides a location to a token file.
 	TokenFile string
-	// Path to optional JSON file containing secrets to seed into service's SecretStore
+	// SecretsFile is optional Path to JSON file containing secrets to seed into service's SecretStore
 	SecretsFile string
+	// DisableScrubSecretsFile specifies to not scrub secrets file after importing. Service will fail start-up if
+	// not disabled and file can not be written.
+	DisableScrubSecretsFile bool
 }
 
 type Database struct {

--- a/config/types.go
+++ b/config/types.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+
 	"github.com/edgexfoundry/go-mod-secrets/v2/pkg/types"
 )
 
@@ -107,6 +108,8 @@ type SecretStoreInfo struct {
 	Authentication types.AuthenticationInfo
 	// TokenFile provides a location to a token file.
 	TokenFile string
+	// Path to optional JSON file containing secrets to seed into service's SecretStore
+	SecretsFile string
 }
 
 type Database struct {

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 )
 
+replace github.com/edgexfoundry/go-mod-secrets/v2 => ../go-mod-secrets
+
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,10 @@ require (
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0
-	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.0
+	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.1-dev.4
 	github.com/gorilla/mux v1.7.4
 	github.com/pelletier/go-toml v1.9.4
 	github.com/stretchr/testify v1.7.0
 )
-
-replace github.com/edgexfoundry/go-mod-secrets/v2 => ../go-mod-secrets
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/edgexfoundry/go-mod-registry/v2 v2.0.0
 	github.com/edgexfoundry/go-mod-secrets/v2 v2.0.1-dev.4
 	github.com/gorilla/mux v1.7.4
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/pelletier/go-toml v1.9.4
 	github.com/stretchr/testify v1.7.0
 )


### PR DESCRIPTION
Secrets are seeded from a JSON file specified by the SecretStore.SecretsFile setting
If SecretsFile setting is blank, seeding is skipped.

closes #273

This PR depends on https://github.com/edgexfoundry/go-mod-secrets/pull/126 to be merged first.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/CONTRIBUTING.md -->

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  https://github.com/edgexfoundry/edgex-docs/pull/587

## Testing Instructions

1. Start edgex using compose builder `make run ds-camera`
   - This will create the `SecretStore` for device camera
2. Stop the Device Camera container
1. Clone branch for this PR and branch for go-mod-secrets PR  https://github.com/edgexfoundry/go-mod-secrets/pull/126
2. Add the following to device-sdk-go `go.mod`

```
replace (
	github.com/edgexfoundry/go-mod-bootstrap/v2 => ../go-mod-bootstrap
)
```
3. Add following the device-camera-go `go.mod`
```
replace (
	github.com/edgexfoundry/device-sdk-go/v2 => ../device-sdk-go
	github.com/edgexfoundry/go-mod-bootstrap/v2 => ../go-mod-bootstrap
)
```
4. Build device-camera
5. cd to `cmd` folder in device-camera-go
6. create file `/tmp/camera-secrets.json` with the following JSON:
    ```json
    {
        "secrets": [
            {
                "path": "credentials001",
                "imported": false,
                "secretData": [
                    {
                        "key": "username",
                        "value": "my-user-1"
                    },
                                    {
                        "key": "password",
                        "value": "password-001"
                    }
                ]
            }
        ]
    }
    ```
7. run `sudo EDGEX_SECURITY_SECRET_STORE=true SECRETSTORE_SECRETSFILE=/tmp/camera-secrets.json ./device-camera`
8. Device Camera logs will have the following:
```
level=INFO ts=2021-09-27T18:22:23.1861784Z app=device-camera source=secret.go:52 msg="Creating SecretClient"
level=INFO ts=2021-09-27T18:22:23.1862282Z app=device-camera source=secret.go:59 msg="Reading secret store configuration and authentication token"
level=INFO ts=2021-09-27T18:22:23.1878451Z app=device-camera source=secret.go:71 msg="Attempting to create secret client"
level=INFO ts=2021-09-27T18:22:23.2092923Z app=device-camera source=secrets.go:277 msg="kick off token renewal with interval: 30m0s"
level=INFO ts=2021-09-27T18:22:23.209413Z app=device-camera source=secure.go:229 msg="Seeding 1 Service Secrets"
level=INFO ts=2021-09-27T18:22:23.2115168Z app=device-camera source=secure.go:248 msg="Secret for 'credentials001' successfully stored."
level=INFO ts=2021-09-27T18:22:23.2117384Z app=device-camera source=secure.go:218 msg="Scrubbing of secrets file complete."
level=INFO ts=2021-09-27T18:22:23.2117899Z app=device-camera source=secret.go:88 msg="Created SecretClient"
``` 
**And will `NOT` display any error getting secrets, but will fail to initialize the camera since no camera exists.**
9. The `/tmp/camera-secrets.json` file contents are now:
```
"secrets":[{"path":"credentials001","imported":true,"secretData":[]}]}
```
10. recreate `/tmp/camera-secrets.json` file contents as above with secret data.
11. run `sudo EDGEX_SECURITY_SECRET_STORE=true SECRETSTORE_SECRETSFILE=/tmp/camera-secrets.json SECRETSTORE_DISABLESCRUBSECRETSFILE=true ./device-camera`
12. Device Camera logs will have the following additional message:
```
level=INFO ts=2021-09-27T18:18:12.3870583Z app=device-camera source=secure.go:210 msg="Scrubbing of secrets file disable."
```
13. The `/tmp/camera-secrets.json` file contents will not be changed. I.e. secret data will still be present in the file

## New Dependency Instructions (If applicable)
**N/A**