### PR TITLE
fix: Correct the CORS handler logic

### DIFF
--- a/bootstrap/handlers/httpcors.go
+++ b/bootstrap/handlers/httpcors.go
@@ -1,0 +1,72 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+)
+
+const (
+	Origin                        = "Origin"
+	Vary                          = "Vary"
+	AccessControlRequestMethod    = "Access-Control-Request-Method"
+	AccessControlExposeHeaders    = "Access-Control-Expose-Headers"
+	AccessControlAllowCredentials = "Access-Control-Allow-Credentials"
+	AccessControlAllowOrigin      = "Access-Control-Allow-Origin"
+	AccessControlAllowMethods     = "Access-Control-Allow-Methods"
+	AccessControlAllowHeaders     = "Access-Control-Allow-Headers"
+	AccessControlMaxAge           = "Access-Control-Max-Age"
+)
+
+// ProcessCORS is a middleware function that enables CORS responses and sets CORS headers.
+func ProcessCORS(corsInfo config.CORSConfigurationInfo) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if corsInfo.EnableCORS && r.Header.Get(Origin) != "" {
+				// Set Access-Control-Expose-Headers only if it's not a preflight request
+				// If the http method is OPTIONS with Access-Control-Request-Methods headers, it means a preflight request
+				if !(r.Method == http.MethodOptions && r.Header.Get(AccessControlRequestMethod) != "") {
+					if len(corsInfo.CORSExposeHeaders) > 0 {
+						w.Header().Set(AccessControlExposeHeaders, corsInfo.CORSExposeHeaders)
+					}
+				}
+
+				if len(corsInfo.CORSAllowedOrigin) > 0 {
+					w.Header().Set(AccessControlAllowOrigin, corsInfo.CORSAllowedOrigin)
+				}
+				if corsInfo.CORSAllowCredentials {
+					w.Header().Set(AccessControlAllowCredentials, "true")
+				}
+
+				w.Header().Set(Vary, Origin)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// HandlePreflight returns a http handler function that process CORS preflight responses and sets CORS headers.
+func HandlePreflight(corsInfo config.CORSConfigurationInfo) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if corsInfo.EnableCORS && r.Header.Get(Origin) != "" {
+			if len(corsInfo.CORSAllowedMethods) > 0 {
+				w.Header().Set(AccessControlAllowMethods, corsInfo.CORSAllowedMethods)
+			}
+			if len(corsInfo.CORSAllowedHeaders) > 0 {
+				w.Header().Set(AccessControlAllowHeaders, corsInfo.CORSAllowedHeaders)
+			}
+			if corsInfo.CORSMaxAge > 0 {
+				w.Header().Set(AccessControlMaxAge, strconv.Itoa(corsInfo.CORSMaxAge))
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/bootstrap/handlers/httpcors_test.go
+++ b/bootstrap/handlers/httpcors_test.go
@@ -1,0 +1,121 @@
+//
+// Copyright (C) 2021 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	defaultCORSAllowCredentials = "true"
+	defaultCORSAllowedOrigin    = "https://localhost"
+	defaultCORSAllowedMethods   = "GET, POST, PUT, PATCH, DELETE"
+	defaultCORSAllowedHeaders   = "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+	defaultCORSExposeHeaders    = "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+	defaultCORSMaxAge           = "3600"
+)
+
+var defaultCORSInfo = config.CORSConfigurationInfo{CORSAllowCredentials: true, CORSAllowedOrigin: defaultCORSAllowedOrigin, CORSAllowedMethods: defaultCORSAllowedMethods, CORSAllowedHeaders: defaultCORSAllowedHeaders, CORSExposeHeaders: defaultCORSExposeHeaders, CORSMaxAge: 3600}
+
+func TestProcessCORS(t *testing.T) {
+	corsInfo := defaultCORSInfo
+
+	simpleHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	tests := []struct {
+		Name                                  string
+		EnableCORS                            bool
+		HttpMethod                            string
+		Origin                                string
+		AccessControlRequestMethod            string
+		ExpectedAccessControlExposeHeaders    string
+		ExpectedAccessControlAllowOrigin      string
+		ExpectedAccessControlAllowCredentials string
+		ExpectedVary                          string
+	}{
+		{"not enable CORS", false, http.MethodGet, "http://test.com", http.MethodGet, "", "", "", ""},
+		{"enable CORS without Origin header", true, http.MethodGet, "", http.MethodGet, "", "", "", ""},
+		{"enable CORS and receive a preflight request", true, http.MethodOptions, "http://test.com", http.MethodGet, "", defaultCORSAllowedOrigin, defaultCORSAllowCredentials, Origin},
+		{"enable CORS and receive an actual request", true, http.MethodGet, "http://test.com", "", defaultCORSExposeHeaders, defaultCORSAllowedOrigin, defaultCORSAllowCredentials, Origin},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			corsInfo.EnableCORS = testCase.EnableCORS
+			corsMiddleware := ProcessCORS(corsInfo)
+			handler := corsMiddleware(simpleHandler)
+
+			req, err := http.NewRequest(testCase.HttpMethod, "/", http.NoBody)
+			require.NoError(t, err)
+
+			if len(testCase.Origin) > 0 {
+				req.Header.Set(Origin, testCase.Origin)
+			}
+			if len(testCase.AccessControlRequestMethod) > 0 {
+				req.Header.Set(AccessControlRequestMethod, testCase.AccessControlRequestMethod)
+			}
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			resp := recorder.Result()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode, "http status code is not as expected")
+			assert.Equal(t, testCase.ExpectedAccessControlExposeHeaders, resp.Header.Get(AccessControlExposeHeaders), "http header Access-Control-Expose-Headers is not as expected")
+			assert.Equal(t, testCase.ExpectedAccessControlAllowOrigin, resp.Header.Get(AccessControlAllowOrigin), "http header Access-Control-Allow-Origin is not as expected")
+			assert.Equal(t, testCase.ExpectedAccessControlAllowCredentials, resp.Header.Get(AccessControlAllowCredentials), "http header Access-Control-Expose-Headers is not as expected")
+			assert.Equal(t, testCase.ExpectedVary, resp.Header.Get(Vary), "http header Vary is not as expected")
+		})
+	}
+}
+
+func TestHandlePreflight(t *testing.T) {
+	corsInfo := defaultCORSInfo
+
+	tests := []struct {
+		Name                              string
+		EnableCORS                        bool
+		Origin                            string
+		ExpectedAccessControlAllowMethods string
+		ExpectedAccessControlAllowHeaders string
+		ExpectedAccessControlMaxAge       string
+	}{
+		{"not enable CORS", false, "http://test.com", "", "", ""},
+		{"enable CORS without Origin header", true, "", "", "", ""},
+		{"enable CORS and receive a preflight request", true, "http://test.com", defaultCORSAllowedMethods, defaultCORSAllowedHeaders, defaultCORSMaxAge},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.Name, func(t *testing.T) {
+			corsInfo.EnableCORS = testCase.EnableCORS
+			handler := http.HandlerFunc(HandlePreflight(corsInfo))
+
+			req, err := http.NewRequest(http.MethodGet, "/", http.NoBody)
+			require.NoError(t, err)
+
+			if len(testCase.Origin) > 0 {
+				req.Header.Set(Origin, testCase.Origin)
+			}
+
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			resp := recorder.Result()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode, "http status code is not as expected")
+			assert.Equal(t, testCase.ExpectedAccessControlAllowMethods, resp.Header.Get(AccessControlAllowMethods), "http header Access-Control-Allow-Methods is not as expected")
+			assert.Equal(t, testCase.ExpectedAccessControlAllowHeaders, resp.Header.Get(AccessControlAllowHeaders), "http header Access-Control-Allow-Headers is not as expected")
+			assert.Equal(t, testCase.ExpectedAccessControlMaxAge, resp.Header.Get(AccessControlMaxAge), "http header Access-Control-Max-Age is not as expected")
+		})
+	}
+}

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2021 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -23,7 +24,6 @@ import (
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
 
 	"github.com/gorilla/mux"
@@ -100,6 +100,11 @@ func (b *HttpServer) BootstrapHandler(
 	})
 	b.router.Use(ProcessCORS(bootstrapConfig.Service.CORSConfiguration))
 
+	// handle the CORS preflight request
+	b.router.Methods(http.MethodOptions).MatcherFunc(func(r *http.Request, rm *mux.RouteMatch) bool {
+		return r.Header.Get(AccessControlRequestMethod) != ""
+	}).HandlerFunc(HandlePreflight(bootstrapConfig.Service.CORSConfiguration))
+
 	server := &http.Server{
 		Addr:    addr,
 		Handler: b.router,
@@ -136,31 +141,4 @@ func (b *HttpServer) BootstrapHandler(
 	}()
 
 	return true
-}
-
-// ProcessCORS is a middleware function that enables CORS preflight responses and sets CORS headers.
-func ProcessCORS(corsInfo config.CORSConfigurationInfo) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if corsInfo.EnableCORS {
-				w.Header().Set("Access-Control-Allow-Credentials", strconv.FormatBool(corsInfo.CORSAllowCredentials))
-				if len(corsInfo.CORSAllowedOrigin) > 0 {
-					w.Header().Set("Access-Control-Allow-Origin", corsInfo.CORSAllowedOrigin)
-				}
-				if len(corsInfo.CORSAllowedMethods) > 0 {
-					w.Header().Set("Access-Control-Allow-Methods", corsInfo.CORSAllowedMethods)
-				}
-				if len(corsInfo.CORSAllowedHeaders) > 0 {
-					w.Header().Set("Access-Control-Allow-Headers", corsInfo.CORSAllowedHeaders)
-				}
-				if len(corsInfo.CORSExposeHeaders) > 0 {
-					w.Header().Set("Access-Control-Expose-Headers", corsInfo.CORSExposeHeaders)
-				}
-				if corsInfo.CORSMaxAge > 0 {
-					w.Header().Set("Access-Control-Max-Age", strconv.Itoa(corsInfo.CORSMaxAge))
-				}
-			}
-			next.ServeHTTP(w, r)
-		})
-	}
 }


### PR DESCRIPTION
Modify CORS process middleware and implement preflight handling to meet:
https://www.html5rocks.com/en/tutorials/cors//#toc-cors-server-flowchart

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)  issue https://github.com/edgexfoundry/edgex-docs/issues/608 opened
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Test normal request:
1. Set configuration `EnableCORS = true`, and start an EdgeX service
2. Send a http request with a header `Origin`
3. Very the response header contains `Access-Control-Expose-Headers`, `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials` with the values the same as the `Service.CORSConfiguration` configuration (if `CORSAllowCredentials = false`, there is no `Access-Control-Allow-Credentials` header), and `Vary: Origin`

Test preflight request:
1. Set configuration `EnableCORS = true` and start an EdgeX service
2. Send an `OPTIONS` http request with a valid header "Access-Control-Request-Method" value, such as `GET`,  and `Origin`
3. Very the response status code is 200 with the header value `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`, `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials`, and `Access-Control-Max-Age` the same as the `Service.CORSConfiguration` configuration (if `CORSAllowCredentials = false`, there is no `Access-Control-Allow-Credentials` header), and `Vary: Origin`
