### PR TITLE
feat: Location of client service obtained from the registry

### DIFF
--- a/bootstrap/container/clients.go
+++ b/bootstrap/container/clients.go
@@ -1,0 +1,143 @@
+//
+// Copyright (c) 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/interfaces"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+)
+
+// EventClientName contains the name of the EventClient's implementation in the DIC.
+var EventClientName = di.TypeInstanceToName((*interfaces.EventClient)(nil))
+
+// EventClientFrom helper function queries the DIC and returns the EventClient's implementation.
+func EventClientFrom(get di.Get) interfaces.EventClient {
+	if get(EventClientName) == nil {
+		return nil
+	}
+
+	return get(EventClientName).(interfaces.EventClient)
+}
+
+// CommandClientName contains the name of the CommandClient's implementation in the DIC.
+var CommandClientName = di.TypeInstanceToName((*interfaces.CommandClient)(nil))
+
+// CommandClientFrom helper function queries the DIC and returns the CommandClient's implementation.
+func CommandClientFrom(get di.Get) interfaces.CommandClient {
+	if get(CommandClientName) == nil {
+		return nil
+	}
+
+	return get(CommandClientName).(interfaces.CommandClient)
+}
+
+// NotificationClientName contains the name of the NotificationClient's implementation in the DIC.
+var NotificationClientName = di.TypeInstanceToName((*interfaces.NotificationClient)(nil))
+
+// NotificationClientFrom helper function queries the DIC and returns the NotificationClient's implementation.
+func NotificationClientFrom(get di.Get) interfaces.NotificationClient {
+	if get(NotificationClientName) == nil {
+		return nil
+	}
+
+	return get(NotificationClientName).(interfaces.NotificationClient)
+}
+
+// SubscriptionClientName contains the name of the SubscriptionClient's implementation in the DIC.
+var SubscriptionClientName = di.TypeInstanceToName((*interfaces.SubscriptionClient)(nil))
+
+// SubscriptionClientFrom helper function queries the DIC and returns the SubscriptionClient's implementation.
+func SubscriptionClientFrom(get di.Get) interfaces.SubscriptionClient {
+	if get(SubscriptionClientName) == nil {
+		return nil
+	}
+
+	return get(SubscriptionClientName).(interfaces.SubscriptionClient)
+}
+
+// DeviceServiceClientName contains the name of the DeviceServiceClient's implementation in the DIC.
+var DeviceServiceClientName = di.TypeInstanceToName((*interfaces.DeviceServiceClient)(nil))
+
+// DeviceServiceClientFrom helper function queries the DIC and returns the DeviceServiceClient's implementation.
+func DeviceServiceClientFrom(get di.Get) interfaces.DeviceServiceClient {
+	if get(DeviceServiceClientName) == nil {
+		return nil
+	}
+
+	return get(DeviceServiceClientName).(interfaces.DeviceServiceClient)
+}
+
+// DeviceProfileClientName contains the name of the DeviceProfileClient's implementation in the DIC.
+var DeviceProfileClientName = di.TypeInstanceToName((*interfaces.DeviceProfileClient)(nil))
+
+// DeviceProfileClientFrom helper function queries the DIC and returns the DeviceProfileClient's implementation.
+func DeviceProfileClientFrom(get di.Get) interfaces.DeviceProfileClient {
+	if get(DeviceProfileClientName) == nil {
+		return nil
+	}
+
+	return get(DeviceProfileClientName).(interfaces.DeviceProfileClient)
+}
+
+// DeviceClientName contains the name of the DeviceClient's implementation in the DIC.
+var DeviceClientName = di.TypeInstanceToName((*interfaces.DeviceClient)(nil))
+
+// DeviceClientFrom helper function queries the DIC and returns the DeviceClient's implementation.
+func DeviceClientFrom(get di.Get) interfaces.DeviceClient {
+	if get(DeviceClientName) == nil {
+		return nil
+	}
+
+	return get(DeviceClientName).(interfaces.DeviceClient)
+}
+
+// ProvisionWatcherClientName contains the name of the ProvisionWatcherClient's implementation in the DIC.
+var ProvisionWatcherClientName = di.TypeInstanceToName((*interfaces.ProvisionWatcherClient)(nil))
+
+// ProvisionWatcherClientFrom helper function queries the DIC and returns the ProvisionWatcherClient's implementation.
+func ProvisionWatcherClientFrom(get di.Get) interfaces.ProvisionWatcherClient {
+	if get(ProvisionWatcherClientName) == nil {
+		return nil
+	}
+
+	return get(ProvisionWatcherClientName).(interfaces.ProvisionWatcherClient)
+}
+
+// IntervalClientName contains the name of the IntervalClient's implementation in the DIC.
+var IntervalClientName = di.TypeInstanceToName((*interfaces.IntervalClient)(nil))
+
+// IntervalClientFrom helper function queries the DIC and returns the IntervalClient's implementation.
+func IntervalClientFrom(get di.Get) interfaces.IntervalClient {
+	if get(IntervalClientName) == nil {
+		return nil
+	}
+
+	return get(IntervalClientName).(interfaces.IntervalClient)
+}
+
+// IntervalActionClientName contains the name of the IntervalActionClient's implementation in the DIC.
+var IntervalActionClientName = di.TypeInstanceToName((*interfaces.IntervalActionClient)(nil))
+
+// IntervalActionClientFrom helper function queries the DIC and returns the IntervalActionClient's implementation.
+func IntervalActionClientFrom(get di.Get) interfaces.IntervalActionClient {
+	if get(IntervalActionClientName) == nil {
+		return nil
+	}
+
+	return get(IntervalActionClientName).(interfaces.IntervalActionClient)
+}
+

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright 2022 Intel Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	clients "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/http"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-registry/v2/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+)
+
+// ClientsBootstrap contains data to boostrap the configured clients
+type ClientsBootstrap struct {
+	registry registry.Client
+}
+
+// NewClientsBootstrap is a factory method that returns the initialized "ClientsBootstrap" receiver struct.
+func NewClientsBootstrap() *ClientsBootstrap {
+	return &ClientsBootstrap{
+	}
+}
+
+// BootstrapHandler fulfills the BootstrapHandler contract.
+// It creates instances of each of the EdgeX clients that are in the service's configuration and place them in the DIC.
+// If the registry is enabled it will be used to get the URL for client otherwise it will use configuration for the url.
+// This handler will fail if an unknown client is specified.
+func (cb *ClientsBootstrap) BootstrapHandler(
+	_ context.Context,
+	_ *sync.WaitGroup,
+	startupTimer startup.Timer,
+	dic *di.Container) bool {
+
+	lc := container.LoggingClientFrom(dic.Get)
+	config := container.ConfigurationFrom(dic.Get)
+	cb.registry = container.RegistryFrom(dic.Get)
+
+	for serviceKey, serviceInfo := range config.GetBootstrap().Clients {
+		url, err := cb.getClientUrl(serviceKey, serviceInfo.Url(), startupTimer)
+		if err != nil {
+			lc.Error(err.Error())
+			return false
+		}
+
+		switch serviceKey {
+		case common.CoreDataServiceKey:
+			dic.Update(di.ServiceConstructorMap{
+				container.EventClientName: func(get di.Get) interface{} {
+					return clients.NewEventClient(url)
+				},
+			})
+		case common.CoreMetaDataServiceKey:
+			dic.Update(di.ServiceConstructorMap{
+				container.DeviceClientName: func(get di.Get) interface{} {
+					return clients.NewDeviceClient(url)
+				},
+				container.DeviceServiceClientName: func(get di.Get) interface{} {
+					return clients.NewDeviceServiceClient(url)
+				},
+				container.DeviceProfileClientName: func(get di.Get) interface{} {
+					return clients.NewDeviceProfileClient(url)
+				},
+				container.ProvisionWatcherClientName: func(get di.Get) interface{} {
+					return clients.NewProvisionWatcherClient(url)
+				},
+
+			})
+
+		case common.CoreCommandServiceKey:
+			dic.Update(di.ServiceConstructorMap{
+				container.CommandClientName: func(get di.Get) interface{} {
+					return clients.NewCommandClient(url)
+				},
+			})
+
+		case common.SupportNotificationsServiceKey:
+			dic.Update(di.ServiceConstructorMap{
+				container.NotificationClientName: func(get di.Get) interface{} {
+					return clients.NewNotificationClient(url)
+				},
+				container.SubscriptionClientName: func(get di.Get) interface{} {
+					return clients.NewSubscriptionClient(url)
+				},
+			})
+
+		case common.SupportSchedulerServiceKey:
+			dic.Update(di.ServiceConstructorMap{
+				container.IntervalClientName: func(get di.Get) interface{} {
+					return clients.NewIntervalClient(url)
+				},
+				container.IntervalActionClientName: func(get di.Get) interface{} {
+					return clients.NewIntervalActionClient(url)
+				},
+			})
+
+		default:
+
+		}
+	}
+
+	return true
+}
+
+func (cb *ClientsBootstrap) getClientUrl(serviceKey string, defaultUrl string, startupTimer startup.Timer) (string, error) {
+	if cb.registry == nil {
+		return defaultUrl, nil
+	}
+
+	var err error
+	var endpoint types.ServiceEndpoint
+
+	for startupTimer.HasNotElapsed() {
+		endpoint, err = cb.registry.GetServiceEndpoint(serviceKey)
+		if err == nil {
+			break
+		}
+
+		startupTimer.SleepForInterval()
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("unable to Get service endpoint for '%s': %s", serviceKey, err.Error())
+	}
+
+	return fmt.Sprintf("http://%s:%v", endpoint.Host, endpoint.Port), nil
+}
+

--- a/bootstrap/handlers/clients_test.go
+++ b/bootstrap/handlers/clients_test.go
@@ -1,0 +1,251 @@
+//
+// Copyright (c) 2022 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
+	"github.com/edgexfoundry/go-mod-registry/v2/pkg/types"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry"
+	"github.com/edgexfoundry/go-mod-registry/v2/registry/mocks"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientsBootstrapHandler(t *testing.T) {
+	lc := logger.NewMockClient()
+
+	coreDataClientInfo := config.ClientInfo{
+		Host:     "localhost",
+		Port:     59880,
+		Protocol: "http",
+	}
+
+	metadataClientInfo := config.ClientInfo{
+		Host:     "localhost",
+		Port:     59881,
+		Protocol: "http",
+	}
+
+	commandClientInfo := config.ClientInfo{
+		Host:     "localhost",
+		Port:     59882,
+		Protocol: "http",
+	}
+
+	notificationClientInfo := config.ClientInfo{
+		Host:     "localhost",
+		Port:     59860,
+		Protocol: "http",
+	}
+
+	subscriberClientInfo := config.ClientInfo{
+		Host:     "localhost",
+		Port:     59861,
+		Protocol: "http",
+	}
+
+	registryMock := &mocks.Client{}
+	registryMock.On("GetServiceEndpoint", common.CoreDataServiceKey).Return(types.ServiceEndpoint{}, nil)
+	registryMock.On("GetServiceEndpoint", common.CoreMetaDataServiceKey).Return(types.ServiceEndpoint{}, nil)
+	registryMock.On("GetServiceEndpoint", common.CoreCommandServiceKey).Return(types.ServiceEndpoint{}, nil)
+	registryMock.On("GetServiceEndpoint", common.SupportNotificationsServiceKey).Return(types.ServiceEndpoint{}, nil)
+	registryMock.On("GetServiceEndpoint", common.SupportSchedulerServiceKey).Return(types.ServiceEndpoint{}, nil)
+
+	registryErrorMock := &mocks.Client{}
+	registryErrorMock.On("GetServiceEndpoint", common.CoreDataServiceKey).Return(types.ServiceEndpoint{}, errors.New("some error"))
+
+	startupTimer := startup.NewTimer(1, 1)
+
+	tests := []struct {
+		Name                   string
+		CoreDataClientInfo     *config.ClientInfo
+		CommandClientInfo      *config.ClientInfo
+		MetadataClientInfo     *config.ClientInfo
+		NotificationClientInfo *config.ClientInfo
+		SchedulerClientInfo    *config.ClientInfo
+		Registry               registry.Client
+		ExpectedResult         bool
+	}{
+		{
+			Name:                   "All ClientsBootstrap",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      &commandClientInfo,
+			MetadataClientInfo:     &metadataClientInfo,
+			NotificationClientInfo: &notificationClientInfo,
+			SchedulerClientInfo:    &subscriberClientInfo,
+			Registry:               nil,
+			ExpectedResult:         true,
+		},
+		{
+			Name:                   "All ClientsBootstrap using registry",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      &commandClientInfo,
+			MetadataClientInfo:     &metadataClientInfo,
+			NotificationClientInfo: &notificationClientInfo,
+			SchedulerClientInfo:    &subscriberClientInfo,
+			Registry:               registryMock,
+			ExpectedResult:         true,
+		},
+		{
+			Name:                   "Core Data Client using registry fails",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     nil,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               registryErrorMock,
+			ExpectedResult:         false,
+		},
+		{
+			Name:                   "No ClientsBootstrap",
+			CoreDataClientInfo:     nil,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     nil,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               nil,
+			ExpectedResult:         true,
+		},
+		{
+			Name:                   "Only Core Data ClientsBootstrap",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     nil,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               nil,
+			ExpectedResult:         true,
+		},
+		{
+			Name:                   "Only Metadata ClientsBootstrap",
+			CoreDataClientInfo:     nil,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     &metadataClientInfo,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               nil,
+			ExpectedResult:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			dic := di.NewContainer(di.ServiceConstructorMap{
+				container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+					return lc
+				},
+				container.RegistryClientInterfaceName: func(get di.Get) interface{} {
+					return test.Registry
+				},
+			})
+
+			clients := make(map[string]config.ClientInfo)
+
+			if test.CoreDataClientInfo != nil {
+				clients[common.CoreDataServiceKey] = coreDataClientInfo
+			}
+
+			if test.CommandClientInfo != nil {
+				clients[common.CoreCommandServiceKey] = commandClientInfo
+			}
+
+			if test.MetadataClientInfo != nil {
+				clients[common.CoreMetaDataServiceKey] = metadataClientInfo
+			}
+
+			if test.NotificationClientInfo != nil {
+				clients[common.SupportNotificationsServiceKey] = notificationClientInfo
+			}
+
+			if test.SchedulerClientInfo != nil {
+				clients[common.SupportSchedulerServiceKey] = subscriberClientInfo
+			}
+
+			actualResult := NewClientsBootstrap(clients).BootstrapHandler(context.Background(), &sync.WaitGroup{}, startupTimer, dic)
+			require.Equal(t, actualResult, test.ExpectedResult)
+			if test.ExpectedResult == false {
+				return
+			}
+
+			eventClient := container.EventClientFrom(dic.Get)
+			commandClient := container.CommandClientFrom(dic.Get)
+			deviceServiceClient := container.DeviceServiceClientFrom(dic.Get)
+			deviceProfileClient := container.DeviceProfileClientFrom(dic.Get)
+			deviceClient := container.DeviceClientFrom(dic.Get)
+			provisionWatcherClient := container.ProvisionWatcherClientFrom(dic.Get)
+			notificationClient := container.NotificationClientFrom(dic.Get)
+			subscriptionClient := container.SubscriptionClientFrom(dic.Get)
+			intervalClient := container.IntervalClientFrom(dic.Get)
+			intervalActionClient := container.IntervalActionClientFrom(dic.Get)
+
+			if test.CoreDataClientInfo != nil {
+				assert.NotNil(t, eventClient)
+			} else {
+				assert.Nil(t, eventClient)
+			}
+
+			if test.CommandClientInfo != nil {
+				assert.NotNil(t, commandClient)
+			} else {
+				assert.Nil(t, commandClient)
+			}
+
+			if test.MetadataClientInfo != nil {
+				assert.NotNil(t, deviceServiceClient)
+				assert.NotNil(t, deviceProfileClient)
+				assert.NotNil(t, deviceClient)
+				assert.NotNil(t, provisionWatcherClient)
+			} else {
+				assert.Nil(t, deviceServiceClient)
+				assert.Nil(t, deviceProfileClient)
+				assert.Nil(t, deviceClient)
+				assert.Nil(t, provisionWatcherClient)
+			}
+
+			if test.NotificationClientInfo != nil {
+				assert.NotNil(t, notificationClient)
+				assert.NotNil(t, subscriptionClient)
+			} else {
+				assert.Nil(t, notificationClient)
+				assert.Nil(t, subscriptionClient)
+			}
+
+			if test.SchedulerClientInfo != nil {
+				assert.NotNil(t, intervalClient)
+				assert.NotNil(t, intervalActionClient)
+			} else {
+				assert.Nil(t, intervalClient)
+				assert.Nil(t, intervalActionClient)
+			}
+
+			if test.Registry != nil {
+				registryMock.AssertExpectations(t)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #304

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **Not needed**

## Testing Instructions
Use this branch in App SDK's App template
Put break point in code just after endpoint is requested from registry
Run app template in debug with `-r` and `EDGEX_SECURITY_SECRET_STORE=false`
Display endpoint returned at breakpoint, which should have hostname set to `edgex-<service-key` as apposed to `localhost`.
ReRun app template in debug with out `-r`
Display endpoint returned at breakpoint, which should have hostname set to `localhost`.

## New Dependency Instructions (If applicable)
**N/A**