### PR TITLE
fix: Generate proper Consul base path on Windows

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
- * Copyright 2021 Intel Inc.
+ * Copyright 2022 Intel Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"reflect"
 	"sync"
 
@@ -336,7 +335,14 @@ func (cp *Processor) createProviderClient(
 	providerConfig types.ServiceConfig) (configuration.Client, error) {
 
 	var err error
-	providerConfig.BasePath = filepath.Join(configStem, ConfigVersion, serviceKey)
+
+	// The passed in configStem already contains the trailing '/' in most cases so must verify and add if missing.
+	if configStem[len(configStem)-1] != '/' {
+		configStem = configStem + "/"
+	}
+
+	// Note: Can't use filepath.Join as it uses `\` on Windows which Consul doesn't recognize as a path separator.
+	providerConfig.BasePath = fmt.Sprintf("%s%s/%s", configStem, ConfigVersion, serviceKey)
 	if getAccessToken != nil {
 		providerConfig.AccessToken, err = getAccessToken()
 		if err != nil {


### PR DESCRIPTION
fixes #299

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **section of code is not unit test-able**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) ** N/A**

## Testing Instructions
Use this branch in App SDK's app template
Run Edgex non-secure stack
Build App template on **Windows**
Run app template with -cp option on **Windows**
Verify Consul contains the configuration at `http://localhost:8500/ui/dc1/kv/edgex/appservices/2.0/new-app-service/`
Via Consul, remove configuration at `http://localhost:8500/ui/dc1/kv/edgex/appservices/2.0/new-app-service/`
Build App template on **Linux**
Run app template with -cp option on **Linux**
Verify Consul contains the configuration at `http://localhost:8500/ui/dc1/kv/edgex/appservices/2.0/new-app-service/`

## New Dependency Instructions (If applicable)
N/A