### PR TITLE
refactor: Rework how Metrics Reporter gets the Messaging Client

### DIFF
--- a/bootstrap/handlers/metrics.go
+++ b/bootstrap/handlers/metrics.go
@@ -20,13 +20,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
+
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/metrics"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
-	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 )
 
 type RegisterTelemetryFunc func(logger.LoggingClient, *config.TelemetryInfo, interfaces.MetricsManager)
@@ -46,7 +47,6 @@ func (s *ServiceMetrics) BootstrapHandler(ctx context.Context, wg *sync.WaitGrou
 	lc := container.LoggingClientFrom(dic.Get)
 	serviceConfig := container.ConfigurationFrom(dic.Get)
 
-	messageClient := container.MessagingClientFrom(dic.Get)
 	telemetryConfig := serviceConfig.GetTelemetryInfo()
 
 	interval, err := time.ParseDuration(telemetryConfig.Interval)
@@ -55,7 +55,7 @@ func (s *ServiceMetrics) BootstrapHandler(ctx context.Context, wg *sync.WaitGrou
 		return false
 	}
 
-	reporter := metrics.NewMessageBusReporter(lc, s.serviceName, messageClient, telemetryConfig)
+	reporter := metrics.NewMessageBusReporter(lc, s.serviceName, dic, telemetryConfig)
 	manager := metrics.NewManager(lc, interval, reporter)
 
 	manager.Run(ctx, wg)

--- a/bootstrap/metrics/reporter_test.go
+++ b/bootstrap/metrics/reporter_test.go
@@ -27,7 +27,10 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+
 	"github.com/edgexfoundry/go-mod-messaging/v2/messaging/mocks"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 )
@@ -194,7 +197,13 @@ func TestMessageBusReporter_Report(t *testing.T) {
 				assert.Equal(t, expectedTopic, topicArg)
 			})
 
-			target := NewMessageBusReporter(logger.NewMockClient(), expectedServiceName, mockClient, expectedTelemetryConfig)
+			dic := di.NewContainer(di.ServiceConstructorMap{
+				container.MessagingClientName: func(get di.Get) interface{} {
+					return mockClient
+				},
+			})
+
+			target := NewMessageBusReporter(logger.NewMockClient(), expectedServiceName, dic, expectedTelemetryConfig)
 
 			if test.Metric != nil {
 				err = reg.Register(expectedMetricName, test.Metric)


### PR DESCRIPTION
For this to work for App Services the Metrics Reporter must get the
Messaging Client from the DIC the first time Report() is called.

Also added locking around the Read/Write of tags maps

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Start non-secure stack and stop Core Data container
Use this branch in edgex-go 
Build Core Data
Change to Telemetry config to enable both metrics and debug logging
Verify logs have the following every 30sec
```
level=DEBUG ts=2022-04-19T21:58:24.6701809Z app=core-data source=reporter.go:165 msg="Publish 2 metrics to the 'edgex/telemetry/core-data' base topic"
level=DEBUG ts=2022-04-19T21:58:24.6702571Z app=core-data source=manager.go:117 msg="Reported metrics..."
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->