### PR TITLE
feat: Put CA cert into MessageBusInfo for all AuthModes

### DIFF
--- a/bootstrap/messaging/messaging.go
+++ b/bootstrap/messaging/messaging.go
@@ -96,7 +96,9 @@ func SetOptionsAuthData(messageBusInfo *config.MessageBusInfo, lc logger.Logging
 	case AuthModeCert:
 		messageBusInfo.Optional[OptionsCertPEMBlockKey] = string(secretData.CertPemBlock)
 		messageBusInfo.Optional[OptionsKeyPEMBlockKey] = string(secretData.KeyPemBlock)
-	case AuthModeCA:
+	}
+
+	if len(secretData.CaPemBlock) > 0 {
 		messageBusInfo.Optional[OptionsCaPEMBlockKey] = string(secretData.CaPemBlock)
 	}
 


### PR DESCRIPTION
Put CA cert into MessageBusInfo for all auth modes if it is present in the Secret Data.

fix: #323 

Signed-off-by: Felix Ting <felix@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) unit tests sufficient
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) no docs change
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->