### PR TITLE
feat: Enhance metric name matching to match on prefix

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -254,6 +254,6 @@ func (t *TelemetryInfo) MetricEnabled(metricName string) bool {
 		return enabled
 	}
 
-	// Service's metric  name did match any config Metric name.
+	// Service's metric name did not match any config Metric name.
 	return false
 }

--- a/config/types.go
+++ b/config/types.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 
@@ -240,11 +241,19 @@ type TelemetryInfo struct {
 }
 
 // MetricEnabled returns whether the named metric is enabled
-func (t *TelemetryInfo) MetricEnabled(name string) bool {
-	enabled, exists := t.Metrics[name]
-	if !exists {
-		return false
+func (t *TelemetryInfo) MetricEnabled(metricName string) bool {
+	for configMetricName, enabled := range t.Metrics {
+		// Match on config metric name as prefix of passed in metric name (service's metric item name)
+		// This allows for a class of Metrics to be enabled with one configured metric name.
+		// App SDK uses this for PipelineMetrics by appending the pipeline ID to the name
+		// of the metric(s) it is collecting for multiple function pipelines.
+		if !strings.HasPrefix(metricName, configMetricName) {
+			continue
+		}
+
+		return enabled
 	}
 
-	return enabled
+	// Service's metric  name did match any config Metric name.
+	return false
 }

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright 2022 Intel Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTelemetryInfo_MetricEnabled(t *testing.T) {
+	target := TelemetryInfo{}
+
+	manyMetrics := map[string]bool{
+		"OtherMetric":     false,
+		"YourMetric":      false,
+		"MyMetricSpecial": false,
+		"MyMetric":        true,
+	}
+
+	tests := []struct {
+		Name              string
+		Metrics           map[string]bool
+		ServiceMetricName string
+		Expected          bool
+	}{
+		{"Simple Match", manyMetrics, "MyMetric", true},
+		{"Has Prefix Match", manyMetrics, "MyMetric-1234", true},
+		{"No Match", manyMetrics, "1234-MyMetric", false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			target.Metrics = test.Metrics
+			actual := target.MetricEnabled(test.ServiceMetricName)
+			assert.Equal(t, test.Expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
This allows for a class of Metrics to be enabled with one configured
metric name. App SDK uses this for PipelineMetrics by appending the
pipeline ID to the name of the metric(s) it is collecting for multiple
function pipelines.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) 

## Testing Instructions
Run non-secure EdgeX stack and stop Core Data container
Use this branch to build Core Data locally
Change Metric config to enable both metrics
Run with DEBUG logging and verify 2 metrics are reported.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->