### PR TITLE
feat: Add ability to disable metric reporting with interval of 0

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"reflect"
 	"sync"
 	"time"
@@ -519,6 +520,11 @@ func (cp *Processor) listenForChanges(serviceConfig interfaces.Configuration, co
 					if err != nil {
 						lc.Errorf("update telemetry interval value is invalid time duration, using previous value: %s", err.Error())
 						break
+					}
+
+					if interval == 0 {
+						lc.Infof("0 specified for metrics reporting interval. Setting to max duration to effectively disable reporting.")
+						interval = math.MaxInt64
 					}
 
 					metricsManager := container.MetricsManagerFrom(cp.dic.Get)

--- a/bootstrap/handlers/metrics.go
+++ b/bootstrap/handlers/metrics.go
@@ -17,6 +17,7 @@ package handlers
 
 import (
 	"context"
+	"math"
 	"sync"
 	"time"
 
@@ -53,6 +54,11 @@ func (s *ServiceMetrics) BootstrapHandler(ctx context.Context, wg *sync.WaitGrou
 	if err != nil {
 		lc.Errorf("Telemetry interval is invalid time duration: %s", err.Error())
 		return false
+	}
+
+	if interval == 0 {
+		lc.Infof("0 specified for metrics reporting interval. Setting to max duration to effectively disable reporting.")
+		interval = math.MaxInt64
 	}
 
 	reporter := metrics.NewMessageBusReporter(lc, s.serviceName, dic, telemetryConfig)

--- a/bootstrap/metrics/manager_test.go
+++ b/bootstrap/metrics/manager_test.go
@@ -188,3 +188,18 @@ func TestManager_Run_Error(t *testing.T) {
 	mockReporter.AssertExpectations(t)
 	mockLogger.AssertExpectations(t)
 }
+
+func TestManager_ResetInterval(t *testing.T) {
+	mockReporter := &mocks.MetricsReporter{}
+	mockLogger := &mocks2.LoggingClient{}
+
+	expected := time.Millisecond * 1
+
+	m := NewManager(mockLogger, expected, mockReporter)
+	target := m.(*manager)
+	assert.Equal(t, expected, target.interval)
+
+	expected = time.Millisecond * 5
+	target.ResetInterval(expected)
+	assert.Equal(t, expected, target.interval)
+}


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
**TBD**
## Testing Instructions
use branch in Core Data
Build and run Core Data from command line with DEBIG logging
Set interval to 0
Verify logs have following:
```
0 specified for metrics reporting interval. Setting to max duration to effectively disable reporting.
```
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->