### PR TITLE
refactor: Rework metric name reported to be the name from configuration

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -240,8 +240,8 @@ type TelemetryInfo struct {
 	Tags map[string]string
 }
 
-// MetricEnabled returns whether the named metric is enabled
-func (t *TelemetryInfo) MetricEnabled(metricName string) bool {
+// GetEnabledMetricName returns the matching configured Metric name and if it is enabled.
+func (t *TelemetryInfo) GetEnabledMetricName(metricName string) (string, bool) {
 	for configMetricName, enabled := range t.Metrics {
 		// Match on config metric name as prefix of passed in metric name (service's metric item name)
 		// This allows for a class of Metrics to be enabled with one configured metric name.
@@ -251,9 +251,9 @@ func (t *TelemetryInfo) MetricEnabled(metricName string) bool {
 			continue
 		}
 
-		return enabled
+		return configMetricName, enabled
 	}
 
 	// Service's metric name did not match any config Metric name.
-	return false
+	return "", false
 }

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -31,21 +31,23 @@ func TestTelemetryInfo_MetricEnabled(t *testing.T) {
 	}
 
 	tests := []struct {
-		Name              string
-		Metrics           map[string]bool
-		ServiceMetricName string
-		Expected          bool
+		Name               string
+		Metrics            map[string]bool
+		ServiceMetricName  string
+		ExpectedMetricName string
+		ExpectedEnabled    bool
 	}{
-		{"Simple Match", manyMetrics, "MyMetric", true},
-		{"Has Prefix Match", manyMetrics, "MyMetric-1234", true},
-		{"No Match", manyMetrics, "1234-MyMetric", false},
+		{"Simple Match", manyMetrics, "MyMetric", "MyMetric", true},
+		{"Has Prefix Match", manyMetrics, "MyMetric-1234", "MyMetric", true},
+		{"No Match", manyMetrics, "1234-MyMetric", "", false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			target.Metrics = test.Metrics
-			actual := target.MetricEnabled(test.ServiceMetricName)
-			assert.Equal(t, test.Expected, actual)
+			actualName, actualEnabled := target.GetEnabledMetricName(test.ServiceMetricName)
+			assert.Equal(t, test.ExpectedEnabled, actualEnabled)
+			assert.Equal(t, test.ExpectedMetricName, actualName)
 		})
 	}
 }


### PR DESCRIPTION
This allows the common metrics controlled by name to be reported as a
single metric. The service must add a Tag to the individual metrics
collected so the data can be seprated.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
     TBD

## Testing Instructions
Build App Template with module from this branch
Run from command line with DEBUG logging and verify 8 metrics being reported.
Run ASC with metrics-influxdb using the following command
```
./app-service-configurable -p=metrics-influxdb | grep "Transformed Metric to"
```
Verify logs contain metrics with the names from App Templates Config and tags for the pipeline ids
```
'PipelineMessagesProcessed,service=new-app-service,pipeline=Floats counter-count=14 1651091700525228000' in pipeline 'default-pipeline"

```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->