### PR TITLE
fix(config): (jakarta) ignore first change notification for custom config

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -54,7 +54,7 @@ func translateInterruptToCancel(ctx context.Context, wg *sync.WaitGroup, cancel 
 	go func() {
 		defer wg.Done()
 
-		signalStream := make(chan os.Signal)
+		signalStream := make(chan os.Signal, 1)
 		defer func() {
 			signal.Stop(signalStream)
 			close(signalStream)

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -308,6 +308,8 @@ func (cp *Processor) ListenForCustomConfigChanges(
 
 		configClient.WatchForChanges(updateStream, errorStream, configToWatch, sectionName)
 
+		isFirstUpdate := true
+
 		for {
 			select {
 			case <-cp.ctx.Done():
@@ -319,6 +321,14 @@ func (cp *Processor) ListenForCustomConfigChanges(
 				cp.lc.Error(ex.Error())
 
 			case raw := <-updateStream:
+				// Config Provider sends an update as soon as the watcher is connected even though there are not
+				// any changes to the configuration. This causes an issue during start-up if there is an
+				// envVars override of one of the Writable fields, so we must ignore the first update.
+				if isFirstUpdate {
+					isFirstUpdate = false
+					continue
+				}
+
 				cp.lc.Infof("Updated custom configuration '%s' has been received from the Configuration Provider", sectionName)
 				changedCallback(raw)
 			}


### PR DESCRIPTION
fixes #314 for Jakarta
Backport of this PR: https://github.com/edgexfoundry/go-mod-bootstrap/pull/315

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Use PR branch in Jakarta version of APP SDK
Build App Template.
Start app w/o override of `APPCUSTOM_SOMEVALUE`
Restart app with override of `APPCUSTOM_SOMEVALUE=999`
Verify logs DO NOT contain message about AppCustom.SomeValue has changed to 123 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->