### PR TITLE
fix: Ensure exit with non-zero code when error occurs

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -181,7 +181,7 @@ func Run(
 	useSecretProvider bool,
 	handlers []interfaces.BootstrapHandler) {
 
-	wg, deferred, _ := RunAndReturnWaitGroup(
+	wg, deferred, success := RunAndReturnWaitGroup(
 		ctx,
 		cancel,
 		commonFlags,
@@ -194,6 +194,11 @@ func Run(
 		useSecretProvider,
 		handlers,
 	)
+
+	if !success {
+		cancel()
+		os.Exit(1)
+	}
 
 	defer deferred()
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -196,6 +196,8 @@ func Run(
 	)
 
 	if !success {
+		// This only occurs when a bootstrap handler has fail.
+		// The handler will have logged an error, so not need to log a message here.
 		cancel()
 		os.Exit(1)
 	}

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -141,7 +141,7 @@ func (b *HttpServer) BootstrapHandler(
 		b.isRunning = true
 		err := server.ListenAndServe()
 		// "Server closed" error occurs when Shutdown above is called in the Done processing, so it can be ignored
-		if err != nil && err.Error() != "http: Server closed" {
+		if err != nil && err != http.ErrServerClosed {
 			// Other errors occur during bootstrapping, like port bind fails, are considered fatal
 			lc.Errorf("Web server failed: %v", err)
 			cancel := container.CancelFuncFrom(dic.Get)

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -150,7 +150,7 @@ func (b *HttpServer) BootstrapHandler(
 			cancel()
 
 			// Wait for all long-running go functions to stop before exiting.
-			wg.Done()
+			wg.Done() // Must do this to account for this go func's wg.Add above otherwise wait will block indefinitely
 			wg.Wait()
 			os.Exit(1)
 		} else {


### PR DESCRIPTION
fixes #318

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Not unit testable**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
Use this branch in device SDK and Device Rest
Run Device Rest
Press control C
Verify  `echo $?` returns 0
Run Device Rest
Run Device Rest in another terminal
Verify if fails due to port bind error
Verify  `echo $?` returns 1

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->