### PR TITLE
fix: Run WatchForChange in a new thread

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -458,7 +458,7 @@ func (cp *Processor) listenForChanges(serviceConfig interfaces.Configuration, co
 		updateStream := make(chan interface{})
 		defer close(updateStream)
 
-		configClient.WatchForChanges(updateStream, errorStream, serviceConfig.EmptyWritablePtr(), writableKey)
+		go configClient.WatchForChanges(updateStream, errorStream, serviceConfig.EmptyWritablePtr(), writableKey)
 
 		for {
 			select {

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -468,7 +468,7 @@ func (cp *Processor) listenForChanges(serviceConfig interfaces.Configuration, co
 				return
 
 			case ex := <-errorStream:
-				lc.Error(ex.Error())
+				lc.Errorf("error occurred during listening to the configuration changes: %s", ex.Error())
 
 			case raw, ok := <-updateStream:
 				if !ok {


### PR DESCRIPTION
fixes #361.
Run WatchForChange in a new thread to receive the error chan.

Signed-off-by: Lindsey Cheng <beckysocute@gmail.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) N/A
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) N/A, it's the internal behavior
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->