### PR TITLE
feat: add new 'Topics' field and external MQTT BootstrapHandler

### DIFF
--- a/bootstrap/container/externalmqtt.go
+++ b/bootstrap/container/externalmqtt.go
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2022 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+)
+
+// ExternalMQTTMessagingClientName contains the name of the external messaging client instance in the DIC.
+var ExternalMQTTMessagingClientName = di.TypeInstanceToName((*mqtt.Client)(nil))
+
+// ExternalMQTTMessagingClientFrom helper function queries the DIC and returns the external messaging client.
+func ExternalMQTTMessagingClientFrom(get di.Get) mqtt.Client {
+	client, ok := get(ExternalMQTTMessagingClientName).(mqtt.Client)
+	if !ok {
+		return nil
+	}
+
+	return client
+}

--- a/bootstrap/handlers/externalmqtt.go
+++ b/bootstrap/handlers/externalmqtt.go
@@ -1,0 +1,171 @@
+//
+// Copyright (C) 2022 IOTech Ltd
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/messaging"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/bootstrap/startup"
+	"github.com/edgexfoundry/go-mod-bootstrap/v2/di"
+)
+
+type ExternalMQTT struct {
+	onConnectHandler mqtt.OnConnectHandler
+}
+
+func NewExternalMQTT(onConnectHandler mqtt.OnConnectHandler) *ExternalMQTT {
+	return &ExternalMQTT{onConnectHandler: onConnectHandler}
+}
+
+func (e *ExternalMQTT) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupTimer startup.Timer, dic *di.Container) bool {
+	lc := container.LoggingClientFrom(dic.Get)
+	configuration := container.ConfigurationFrom(dic.Get)
+
+	brokerConfig := configuration.GetBootstrap().ExternalMQTT
+	topics := brokerConfig.SubscribeTopics
+	// TODO: remove first check and update error log in EdgeX 3.0
+	if len(strings.TrimSpace(topics)) == 0 && len(brokerConfig.Topics) == 0 {
+		lc.Errorf("missing SubscribeTopics and/or Topics for external MQTT connection. Must be present in [MessageQueue.External] section")
+		return false
+	}
+
+	_, err := url.Parse(brokerConfig.Url)
+	if err != nil {
+		lc.Errorf("invalid MQTT Broker Url '%s': %s", brokerConfig.Url, err.Error())
+		return false
+	}
+
+	opts := mqtt.NewClientOptions()
+	opts.AddBroker(brokerConfig.Url)
+	opts.SetClientID(brokerConfig.ClientId)
+	opts.SetOnConnectHandler(e.onConnectHandler)
+	opts.SetAutoReconnect(brokerConfig.AutoReconnect)
+	opts.KeepAlive = brokerConfig.KeepAlive
+	if len(brokerConfig.ConnectTimeout) > 0 {
+		duration, err := time.ParseDuration(brokerConfig.ConnectTimeout)
+		if err != nil {
+			lc.Errorf("invalid MQTT ConnectTimeout '%s': %s", brokerConfig.ConnectTimeout, err.Error())
+			return false
+		}
+		opts.SetConnectTimeout(duration)
+	}
+
+	secretProvider := container.SecretProviderFrom(dic.Get)
+	authMode := brokerConfig.AuthMode
+	if brokerConfig.AuthMode == "" {
+		authMode = messaging.AuthModeNone
+		lc.Warn("AuthMode not set, defaulting to \"" + messaging.AuthModeNone + "\"")
+	}
+
+	//get the secrets from the secret provider and populate the struct
+	secretData, err := messaging.GetSecretData(authMode, brokerConfig.SecretPath, secretProvider)
+	if err != nil {
+		lc.Errorf("Failed to retrieve secret data: %s", err.Error())
+		return false
+	}
+	//ensure that the AuthMode selected has the required secret values
+	if secretData != nil {
+		err = messaging.ValidateSecretData(authMode, brokerConfig.SecretPath, secretData)
+		if err != nil {
+			lc.Errorf("Invalid secret data: %s", err.Error())
+			return false
+		}
+
+		// configure the mqtt client with the retrieved secret values
+		tlsConfig := &tls.Config{
+			// nolint: gosec
+			InsecureSkipVerify: brokerConfig.SkipCertVerify,
+			MinVersion:         tls.VersionTLS12,
+		}
+		switch authMode {
+		case messaging.AuthModeUsernamePassword:
+			opts.SetUsername(secretData.Username)
+			opts.SetPassword(secretData.Password)
+		case messaging.AuthModeCert:
+			cert, err := tls.X509KeyPair(secretData.CertPemBlock, secretData.KeyPemBlock)
+			if err != nil {
+				lc.Errorf("Failed to parse public/private key pair: %s", err.Error())
+				return false
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		case messaging.AuthModeCA:
+			// Nothing to do here for this option
+		case messaging.AuthModeNone:
+			// Nothing to do here for this option
+		}
+
+		if len(secretData.CaPemBlock) > 0 {
+			caCertPool := x509.NewCertPool()
+			ok := caCertPool.AppendCertsFromPEM(secretData.CaPemBlock)
+			if !ok {
+				lc.Errorf("error parsing CA PEM block")
+				return false
+			}
+			tlsConfig.RootCAs = caCertPool
+		}
+
+		opts.SetTLSConfig(tlsConfig)
+	}
+
+	var mqttClient mqtt.Client
+	for startupTimer.HasNotElapsed() {
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			mqttClient, err = createMqttClient(opts)
+			if err != nil {
+				lc.Warnf("Unable to create MQTT client: %s", err.Error())
+				startupTimer.SleepForInterval()
+				continue
+			}
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-ctx.Done()
+				mqttClient.Disconnect(0)
+				lc.Info("Disconnected from external MQTT broker")
+			}()
+
+			dic.Update(di.ServiceConstructorMap{
+				container.ExternalMQTTMessagingClientName: func(get di.Get) interface{} {
+					return mqttClient
+				},
+			})
+
+			lc.Infof(
+				"Connected to external MQTT broker @ %s with AuthMode='%s'",
+				brokerConfig.Url,
+				brokerConfig.AuthMode)
+
+			return true
+		}
+	}
+
+	lc.Error("Connecting to external MQTT broker time out")
+	return false
+}
+
+func createMqttClient(opts *mqtt.ClientOptions) (mqtt.Client, error) {
+	mqttClient := mqtt.NewClient(opts)
+	if token := mqttClient.Connect(); token.Wait() && token.Error() != nil {
+		return nil, fmt.Errorf("could not connect to broker: %s", token.Error().Error())
+	}
+
+	return mqttClient, nil
+}

--- a/bootstrap/handlers/messaging.go
+++ b/bootstrap/handlers/messaging.go
@@ -80,7 +80,7 @@ func MessagingBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupT
 		default:
 			err = msgClient.Connect()
 			if err != nil {
-				lc.Warnf("Unable to connect MessageBus: %w", err)
+				lc.Warnf("Unable to connect MessageBus: %s", err.Error())
 				startupTimer.SleepForInterval()
 				continue
 			}

--- a/config/types.go
+++ b/config/types.go
@@ -188,6 +188,7 @@ type BootstrapConfiguration struct {
 	Registry     RegistryInfo
 	SecretStore  SecretStoreInfo
 	MessageQueue MessageBusInfo
+	ExternalMQTT ExternalMQTTInfo
 }
 
 // MessageBusInfo provides parameters related to connecting to a message bus as a publisher
@@ -222,6 +223,41 @@ type MessageBusInfo struct {
 	// Topics allows MessageBusInfo to be more flexible with respect to topics.
 	// TODO: move PublishTopicPrefix and SubscribeTopic to Topics in EdgeX 3.0
 	Topics map[string]string
+}
+
+type ExternalMQTTInfo struct {
+	// Url contains the fully qualified URL to connect to the MQTT broker
+	Url string
+	// SubscribeTopics is a comma separated list of topics in which to subscribe
+	SubscribeTopics string
+	// PublishTopic is the topic to publish pipeline output (if any)
+	PublishTopic string
+	// Topics allows ExternalMQTTInfo to be more flexible with respect to topics.
+	// TODO: move PublishTopic and SubscribeTopics to Topics in EdgeX 3.0
+	Topics map[string]string
+	// ClientId to connect to the broker with.
+	ClientId string
+	// ConnectTimeout is a time duration indicating how long to wait timing out on the broker connection
+	ConnectTimeout string
+	// AutoReconnect indicated whether to retry connection if disconnected
+	AutoReconnect bool
+	// KeepAlive is seconds between client ping when no active data flowing to avoid client being disconnected
+	KeepAlive int64
+	// QoS for MQTT Connection
+	QoS byte
+	// Retain setting for MQTT Connection
+	Retain bool
+	// SkipCertVerify indicates if the certificate verification should be skipped
+	SkipCertVerify bool
+	// SecretPath is the name of the path in secret provider to retrieve your secrets
+	SecretPath string
+	// AuthMode indicates what to use when connecting to the broker. Options are "none", "cacert" , "usernamepassword", "clientcert".
+	// If a CA Cert exists in the SecretPath then it will be used for all modes except "none".
+	AuthMode string
+	// RetryDuration indicates how long (in seconds) to wait timing out on the MQTT client creation
+	RetryDuration int
+	// RetryInterval indicates the time (in seconds) that will be waited between attempts to create MQTT client
+	RetryInterval int
 }
 
 // URL constructs a URL from the protocol, host and port and returns that as a string.

--- a/config/types.go
+++ b/config/types.go
@@ -219,6 +219,9 @@ type MessageBusInfo struct {
 	Optional map[string]string
 	// SubscribeEnabled indicates whether enable the subscription to the Message Queue
 	SubscribeEnabled bool
+	// Topics allows MessageBusInfo to be more flexible with respect to topics.
+	// TODO: move PublishTopicPrefix and SubscribeTopic to Topics in EdgeX 3.0
+	Topics map[string]string
 }
 
 // URL constructs a URL from the protocol, host and port and returns that as a string.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/edgexfoundry/go-mod-bootstrap/v2
 go 1.18
 
 require (
+	github.com/eclipse/paho.mqtt.golang v1.4.1
 	github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0
 	github.com/edgexfoundry/go-mod-messaging/v2 v2.2.0
@@ -21,7 +22,6 @@ require (
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/eclipse/paho.mqtt.golang v1.3.5 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
@@ -57,6 +57,7 @@ require (
 	github.com/zeebo/errs v1.2.2 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
-github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
+github.com/eclipse/paho.mqtt.golang v1.4.1 h1:tUSpviiL5G3P9SZZJPC4ZULZJsxQKXxfENpMvdbAXAI=
+github.com/eclipse/paho.mqtt.golang v1.4.1/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0 h1:AZeaAPJM5X93ITFgwbwluYDtYEJ7tkCMSlj35GwfLLU=
 github.com/edgexfoundry/go-mod-configuration/v2 v2.2.0/go.mod h1:YP17JhMnXTitowXE13QJwFaKo0oc03iyoKLjWAYl4FE=
 github.com/edgexfoundry/go-mod-core-contracts/v2 v2.2.0 h1:Sfi9jAIgRXZaJQw8Ji6+8//47D+iOyGiXQSNZXhy3HE=
@@ -257,6 +257,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
to support north-south messaging implementation for internal and
external MessageBus connection

Signed-off-by: Chris Hung <chris@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) new handler depends on mqtt-broker, haven't figured out how to test it
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) wait until the whole implementation is finished
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->
https://github.com/eclipse/paho.mqtt.golang
used by app-functions-sdk-go to connect to external MQTT broker.
We extract the logic here so that it can be reused by north-south messaging implementation and app-sdk in the future.