### PR TITLE
feat: redact logging of insecure secrets env override

### DIFF
--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -46,16 +47,29 @@ const (
 	tomlPathSeparator = "."
 	tomlNameSeparator = "-"
 	envNameSeparator  = "_"
+
+	// insecureSecretsRegexStr is a regex to look for toml keys that are under the Secrets sub-key of values within the
+	// Writable.InsecureSecrets topology.
+	// Examples:
+	//			Matches: Writable.InsecureSecrets.credentials001.Secrets.password
+	//	 Does Not Match: Writable.InsecureSecrets.credentials001.Path
+	insecureSecretsRegexStr = "^Writable\\.InsecureSecrets\\.[^.]+\\.Secrets\\..+$"
+	// redactedStr is the value to print for redacted variable values
+	redactedStr = "<redacted>"
 )
 
-// Variables is receiver that holds Variables variables and encapsulates toml.Tree-based configuration field
+var (
+	insecureSecretsRegex = regexp.MustCompile(insecureSecretsRegexStr)
+)
+
+// Variables is a receiver that holds Variables variables and encapsulates toml.Tree-based configuration field
 // overrides.  Assumes "_" embedded in Variables variable key separates sub-structs; e.g. foo_bar_baz might refer to
 //
-// 		type foo struct {
-// 			bar struct {
-//          	baz string
-//  		}
-//		}
+//			type foo struct {
+//				bar struct {
+//	         		baz string
+//	 			}
+//			}
 type Variables struct {
 	variables map[string]string
 	lc        logger.LoggingClient
@@ -291,7 +305,7 @@ func GetStartupInfo(serviceKey string) StartupInfo {
 	return startup
 }
 
-// GetConfDir get the config directory value from an Variables variable value (if it exists)
+// GetConfDir get the config directory value from a Variables variable value (if it exists)
 // or uses passed in value or default if previous result in blank.
 func GetConfDir(lc logger.LoggingClient, configDir string) string {
 	envValue := os.Getenv(envConfDir)
@@ -307,7 +321,7 @@ func GetConfDir(lc logger.LoggingClient, configDir string) string {
 	return configDir
 }
 
-// GetProfileDir get the profile directory value from an Variables variable value (if it exists)
+// GetProfileDir get the profile directory value from a Variables variable value (if it exists)
 // or uses passed in value or default if previous result in blank.
 func GetProfileDir(lc logger.LoggingClient, profileDir string) string {
 	envValue := os.Getenv(envProfile)
@@ -323,7 +337,7 @@ func GetProfileDir(lc logger.LoggingClient, profileDir string) string {
 	return profileDir
 }
 
-// GetConfigFileName gets the configuration filename value from an Variables variable value (if it exists)
+// GetConfigFileName gets the configuration filename value from a Variables variable value (if it exists)
 // or uses passed in value.
 func GetConfigFileName(lc logger.LoggingClient, configFileName string) string {
 	envValue := os.Getenv(envFile)
@@ -348,6 +362,11 @@ func parseCommaSeparatedSlice(value string) (values []interface{}) {
 }
 
 // logEnvironmentOverride logs that an option or configuration has been override by an environment variable.
+// If the key belongs to a Secret within Writable.InsecureSecrets, the value is redacted when printing it.
 func logEnvironmentOverride(lc logger.LoggingClient, name string, key string, value string) {
-	lc.Info(fmt.Sprintf("Variables override of '%s' by environment variable: %s=%s", name, key, value))
+	valueStr := value
+	if insecureSecretsRegex.MatchString(name) {
+		valueStr = redactedStr
+	}
+	lc.Infof("Variables override of '%s' by environment variable: %s=%s", name, key, valueStr)
 }

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -53,7 +53,7 @@ const (
 	// Examples:
 	//			Matches: Writable.InsecureSecrets.credentials001.Secrets.password
 	//	 Does Not Match: Writable.InsecureSecrets.credentials001.Path
-	insecureSecretsRegexStr = "^Writable\\.InsecureSecrets\\.[^.]+\\.Secrets\\..+$"
+	insecureSecretsRegexStr = "^Writable\\.InsecureSecrets\\.[^.]+\\.Secrets\\..+$" //#nosec G101 -- This is a false positive
 	// redactedStr is the value to print for redacted variable values
 	redactedStr = "<redacted>"
 )


### PR DESCRIPTION
Signed-off-by: Anthony Casagrande <anthony.j.casagrande@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)  **N/A?**

Closes #366 

tested using `go.mod`:
```
replace (
	github.com/edgexfoundry/go-mod-bootstrap/v2 => ../go-mod-bootstrap
)
```
Output:
```
level=INFO ts=2022-09-01T18:52:41.98712185Z app=device-onvif-camera source=config.go:391 msg="Loaded service configuration from ./res/configuration.toml"
level=INFO ts=2022-09-01T18:52:41.987407499Z app=device-onvif-camera source=variables.go:371 msg="Variables override of 'Writable.LogLevel' by environment variable: WRITABLE_LOGLEVEL=DEBUG"
level=INFO ts=2022-09-01T18:52:41.987423113Z app=device-onvif-camera source=variables.go:371 msg="Variables override of 'Writable.InsecureSecrets.credentials001.Secrets.username' by environment variable: WRITABLE_INSECURESECRETS_CREDENTIALS001_SECRETS_USERNAME=<redacted>"
level=INFO ts=2022-09-01T18:52:41.987429307Z app=device-onvif-camera source=variables.go:371 msg="Variables override of 'Writable.InsecureSecrets.credentials001.Secrets.password' by environment variable: WRITABLE_INSECURESECRETS_CREDENTIALS001_SECRETS_PASSWORD=<redacted>"
```