### PR TITLE
feat: Add service metrics for Secrets requested and stored

### DIFF
--- a/bootstrap/interfaces/mocks/SecretProvider.go
+++ b/bootstrap/interfaces/mocks/SecretProvider.go
@@ -113,6 +113,11 @@ func (_m *SecretProvider) ListSecretPaths() ([]string, error) {
 	return r0, r1
 }
 
+// RegisterMetrics provides a mock function with given fields: registerCallback
+func (_m *SecretProvider) RegisterMetrics(registerCallback func(map[string]interface{})) {
+	_m.Called(registerCallback)
+}
+
 // RegisteredSecretUpdatedCallback provides a mock function with given fields: path, callback
 func (_m *SecretProvider) RegisteredSecretUpdatedCallback(path string, callback func(string)) error {
 	ret := _m.Called(path, callback)

--- a/bootstrap/interfaces/secret.go
+++ b/bootstrap/interfaces/secret.go
@@ -4,6 +4,12 @@ import (
 	"time"
 )
 
+// Service Metric Names
+const (
+	SecretsRequestedMetricName = "SecuritySecretsRequested"
+	SecretsStoredMetricName    = "SecuritySecretsStored"
+)
+
 // SecretProvider defines the contract for secret provider implementations that
 // allow secrets to be retrieved/stored from/to a services Secret Store.
 type SecretProvider interface {
@@ -37,4 +43,7 @@ type SecretProvider interface {
 
 	// DeregisterSecretUpdatedCallback removes a secret's registered callback path.
 	DeregisterSecretUpdatedCallback(path string)
+
+	// RegisterMetrics registers all metric objects using the passed in registerCallback.
+	RegisterMetrics(registerCallback func(metrics map[string]interface{}))
 }


### PR DESCRIPTION
applies to #374

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
### Non-secure mode
Run non-secure EdgeX stack
Run ACS with metrics-influxdb profile from command line with DEBUG logging
```
WRITABLE_LOGLEVEL=DEBUG EDGEX_SECURITY_SECRET_STORE=false ./app-service-configurable -p=metrics-influxdb | grep Transformed Metric
```
Build and run app template in App SDk with go-mod-bootstrap from this branch
Disable all exiting metrics in the app template config file
Add the following metrics enabled
```toml
    [Writable.Telemetry.Metrics] # All service's metric names must be present in this list.
    SecuritySecretsRequested = true
    SecuritySecretsStored = true
```
Run app template service from command-line with -cp option so it uses Consul for config and DEBUG logging
```
WRITABLE_LOGLEVEL=DEBUG  DGEX_SECURITY_SECRET_STORE=false ./new-app-service -cp
```
Verify ever 30 secs it logs the following:
```
msg="Publish 2 metrics to the 'edgex/telemetry/app-new-service' base topic"
msg="Reported metrics..."
```
Verify ASC logs have the following:
```
msg="Transformed Metric to 'SecuritySecretsRequested,service=app-new-service counter-count=1 1664992310177494700\n'
msg="Transformed Metric to SecuritySecretsStored,service=app-new-service counter-count=0 1664992310177494700\n'
```
From Consul change the value at `edgex/appservices/2.0/app-new-service/Writable/InsecureSecrets/HTTPS/Secrets/key` and save it.
Verify that ASC logs now show `SecuritySecretsStored` is 1
```
msg="Transformed Metric to SecuritySecretsStored,service=app-new-service counter-count=1 1664992320175487900\n' 
```
### Secure Mode
Generate secure compose with asc-metrics so it adds the service key to the appropriate security services
Edit compose to 
  - remove asc-metrics so it doesn't conflict with locally run instance
  - add the `app-new-service` service key to appropriate security services

Run the customized secure compose file `make run up`
Run ACS with metrics-influxdb profile from command line with DEBUG logging and security on
```
WRITABLE_LOGLEVEL=DEBUG EDGEX_SECURITY_SECRET_STORE=true ./app-service-configurable -p=metrics-influxdb | grep Transformed Metric
```
Run app template service from command-line with DEBUG logging and security on
```
sudo WRITABLE_LOGLEVEL=DEBUG  DGEX_SECURITY_SECRET_STORE=true ./new-app-service -cp
```
Verify ever 30 secs it logs the following:
```
msg="Publish 2 metrics to the 'edgex/telemetry/app-new-service' base topic"
msg="Reported metrics..."
```
Verify ASC logs have the following:
```
msg="Transformed Metric to 'SecuritySecretsRequested,service=app-new-service counter-count=1 1664992310177494700\n'
msg="Transformed Metric to SecuritySecretsStored,service=app-new-service counter-count=0 1664992310177494700\n'
```
Push a new secret into the service SecretStore using the `http://localhost:59740/api/v2/secret` endpoint
```
{
   "apiVersion":"v2",
   "path":"MyPath",
   "secretData":[
      {
         "key":"MySecretKey",
         "value":"MySecretValue"
      }
   ]
}
```
Verify that ASC logs now show `SecuritySecretsStored` is 1
```
msg="Transformed Metric to SecuritySecretsStored,service=app-new-service counter-count=1 1664992320175487900\n' 
```
### Core Support service backward compatibility
Build local binary for Support Notifications 
Run non-secure stack using compose builder 
```
make run no-secty ds-virtual
```
Stop Support Notifications container
Run Support Notifications from command-line
```
WRITABLE_LOGLEVEL=DEBUG  DGEX_SECURITY_SECRET_STORE=false ./support-notifications
```
Verify service starts properly and has the following log message:
```
MetricsManager not available. General common service metrics will not be reported. 
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->