### PR TITLE
fix: Add capability to override config provider settings with "none"

### DIFF
--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -44,6 +44,8 @@ const (
 	envProfile            = "EDGEX_PROFILE"
 	envFile               = "EDGEX_CONFIG_FILE"
 
+	NoConfigProviderValue = "none"
+
 	tomlPathSeparator = "."
 	tomlNameSeparator = "-"
 	envNameSeparator  = "_"
@@ -203,6 +205,10 @@ func (e *Variables) OverrideConfigProviderInfo(configProviderInfo types.ServiceC
 	url := os.Getenv(envKeyConfigUrl)
 	if len(url) > 0 {
 		logEnvironmentOverride(e.lc, "Configuration Provider Information", envKeyConfigUrl, url)
+
+		if url == NoConfigProviderValue {
+			return types.ServiceConfig{}, nil
+		}
 
 		if err := configProviderInfo.PopulateFromUrl(url); err != nil {
 			return types.ServiceConfig{}, err

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -44,7 +44,7 @@ const (
 	envProfile            = "EDGEX_PROFILE"
 	envFile               = "EDGEX_CONFIG_FILE"
 
-	NoConfigProviderValue = "none"
+	noConfigProviderValue = "none"
 
 	tomlPathSeparator = "."
 	tomlNameSeparator = "-"
@@ -206,7 +206,7 @@ func (e *Variables) OverrideConfigProviderInfo(configProviderInfo types.ServiceC
 	if len(url) > 0 {
 		logEnvironmentOverride(e.lc, "Configuration Provider Information", envKeyConfigUrl, url)
 
-		if url == NoConfigProviderValue {
+		if url == noConfigProviderValue {
 			return types.ServiceConfig{}, nil
 		}
 

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -81,7 +81,7 @@ func TestOverrideConfigProviderInfo(t *testing.T) {
 func TestOverrideConfigProviderInfo_none(t *testing.T) {
 	providerConfig, lc := initializeTest()
 
-	err := os.Setenv(envKeyConfigUrl, "none")
+	err := os.Setenv(envKeyConfigUrl, noConfigProviderValue)
 	require.NoError(t, err)
 
 	env := NewVariables(lc)

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -17,12 +17,13 @@ package environment
 
 import (
 	"fmt"
-	loggerMocks "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger/mocks"
-	"github.com/stretchr/testify/mock"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	loggerMocks "github.com/edgexfoundry/go-mod-core-contracts/v2/clients/logger/mocks"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v2/config"
 
@@ -75,6 +76,22 @@ func TestOverrideConfigProviderInfo(t *testing.T) {
 	assert.Equal(t, providerConfig.Port, expectedPortValue)
 	assert.Equal(t, providerConfig.Type, expectedTypeValue)
 	assert.Equal(t, providerConfig.Protocol, expectedProtocolValue)
+}
+
+func TestOverrideConfigProviderInfo_none(t *testing.T) {
+	providerConfig, lc := initializeTest()
+
+	err := os.Setenv(envKeyConfigUrl, "none")
+	require.NoError(t, err)
+
+	env := NewVariables(lc)
+	providerConfig, err = env.OverrideConfigProviderInfo(providerConfig)
+
+	assert.NoError(t, err)
+	assert.Empty(t, providerConfig.Host)
+	assert.Empty(t, providerConfig.Port)
+	assert.Empty(t, providerConfig.Type)
+	assert.Empty(t, providerConfig.Protocol)
 }
 
 func TestOverrideConfigProviderInfo_NoEnvVariables(t *testing.T) {


### PR DESCRIPTION
fixes #375

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
Build Core Data using go-mod-bootstrap from this branch
Run non-secure EdgeX Stack
Stop Core Data and remove Core Data config from Consul
### Override
Run Core Data from command-line using:
```
EDGEX_CONFIGURATION_PROVIDER=none ./core-data -cp
```
Verify logs show override
```
"Variables override of 'Configuration Provider Information' by environment variable: EDGEX_CONFIGURATION_PROVIDER=none"
```
Verify logs don't mention use of config provider
### No Override
Run Core Data from command-line using:
```
 ./core-data -cp
```
Verify logs DO NOT show override as above
Verify logs do mention use of config provider
```
"Using Configuration provider (consul) from: http://localhost:8500 with base path of edgex/core/2.0/core-data"
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->