### PR TITLE
refactor!: Don't add version to Config Stem

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -43,8 +43,7 @@ import (
 )
 
 const (
-	writableKey   = "/Writable"
-	ConfigVersion = "2.0"
+	writableKey = "/Writable"
 )
 
 // UpdatedStream defines the stream type that is notified by ListenForChanges when a configuration update is received.
@@ -355,7 +354,7 @@ func (cp *Processor) createProviderClient(
 	}
 
 	// Note: Can't use filepath.Join as it uses `\` on Windows which Consul doesn't recognize as a path separator.
-	providerConfig.BasePath = fmt.Sprintf("%s%s/%s", configStem, ConfigVersion, serviceKey)
+	providerConfig.BasePath = fmt.Sprintf("%s%s", configStem, serviceKey)
 	if getAccessToken != nil {
 		providerConfig.AccessToken, err = getAccessToken()
 		if err != nil {


### PR DESCRIPTION
BREAKING CHANGE: Service configuration location in Consul has changed

Version is now in the default config stem

closes #400

Note: this PR is dependent on  https://github.com/edgexfoundry/go-mod-core-contracts/pull/776 being merged first.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->