### PR TITLE
feat: Rename environment variables for the sake of consistency

### DIFF
--- a/bootstrap/config/provider_test.go
+++ b/bootstrap/config/provider_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	envKeyConfigUrl = "EDGEX_CONFIGURATION_PROVIDER"
+	envKeyConfigUrl = "EDGEX_CONFIG_PROVIDER"
 	goodUrlValue    = "consul.http://localhost:8500"
 	badUrlValue     = "Not a url"
 

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -34,15 +34,15 @@ import (
 const (
 	bootTimeoutSecondsDefault = 60
 	bootRetrySecondsDefault   = 1
-	defaultConfDirValue       = "./res"
+	defaultConfigDirValue     = "./res"
 
 	envKeyConfigUrl       = "EDGEX_CONFIG_PROVIDER"
 	envKeyUseRegistry     = "EDGEX_USE_REGISTRY"
 	envKeyStartupDuration = "EDGEX_STARTUP_DURATION"
 	envKeyStartupInterval = "EDGEX_STARTUP_INTERVAL"
-	envConfDir            = "EDGEX_CONFIG_DIR"
+	envConfigDir          = "EDGEX_CONFIG_DIR"
 	envProfile            = "EDGEX_PROFILE"
-	envFile               = "EDGEX_CONFIG_FILE"
+	envConfigFile         = "EDGEX_CONFIG_FILE"
 
 	noConfigProviderValue = "none"
 
@@ -314,14 +314,14 @@ func GetStartupInfo(serviceKey string) StartupInfo {
 // GetConfDir get the config directory value from a Variables variable value (if it exists)
 // or uses passed in value or default if previous result in blank.
 func GetConfDir(lc logger.LoggingClient, configDir string) string {
-	envValue := os.Getenv(envConfDir)
+	envValue := os.Getenv(envConfigDir)
 	if len(envValue) > 0 {
 		configDir = envValue
-		logEnvironmentOverride(lc, "-c/-confdir", envConfDir, envValue)
+		logEnvironmentOverride(lc, "-c/-confdir", envConfigDir, envValue)
 	}
 
 	if len(configDir) == 0 {
-		configDir = defaultConfDirValue
+		configDir = defaultConfigDirValue
 	}
 
 	return configDir
@@ -346,10 +346,10 @@ func GetProfileDir(lc logger.LoggingClient, profileDir string) string {
 // GetConfigFileName gets the configuration filename value from a Variables variable value (if it exists)
 // or uses passed in value.
 func GetConfigFileName(lc logger.LoggingClient, configFileName string) string {
-	envValue := os.Getenv(envFile)
+	envValue := os.Getenv(envConfigFile)
 	if len(envValue) > 0 {
 		configFileName = envValue
-		logEnvironmentOverride(lc, "-f/-file", envFile, envValue)
+		logEnvironmentOverride(lc, "-f/-file", envConfigFile, envValue)
 	}
 
 	return configFileName

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -36,11 +36,11 @@ const (
 	bootRetrySecondsDefault   = 1
 	defaultConfDirValue       = "./res"
 
-	envKeyConfigUrl       = "EDGEX_CONFIGURATION_PROVIDER"
+	envKeyConfigUrl       = "EDGEX_CONFIG_PROVIDER"
 	envKeyUseRegistry     = "EDGEX_USE_REGISTRY"
 	envKeyStartupDuration = "EDGEX_STARTUP_DURATION"
 	envKeyStartupInterval = "EDGEX_STARTUP_INTERVAL"
-	envConfDir            = "EDGEX_CONF_DIR"
+	envConfDir            = "EDGEX_CONFIG_DIR"
 	envProfile            = "EDGEX_PROFILE"
 	envFile               = "EDGEX_CONFIG_FILE"
 

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -161,9 +161,9 @@ func TestGetConfDir(t *testing.T) {
 		PassedInName string
 		ExpectedName string
 	}{
-		{"With Env Var", envConfDir, "res", "myres"},
+		{"With Env Var", envConfigDir, "res", "myres"},
 		{"With No Env Var", "", "res", "res"},
-		{"With No Env Var and no passed in", "", "", defaultConfDirValue},
+		{"With No Env Var and no passed in", "", "", defaultConfigDirValue},
 	}
 
 	for _, test := range testCases {
@@ -220,7 +220,7 @@ func TestGetConfigFileName(t *testing.T) {
 		PassedInName string
 		ExpectedName string
 	}{
-		{"With Env Var", envFile, "configuration.toml", "config.toml"},
+		{"With Env Var", envConfigFile, "configuration.toml", "config.toml"},
 		{"With No Env Var", "", "configuration.toml", "configuration.toml"},
 		{"With No Env Var and no passed in", "", "", ""},
 	}


### PR DESCRIPTION
resolve #399 

BREAKING CHANGE:
- `EDGEX_CONFIGURTION_PROVIDER` is replaced by `EDGEX_CONFIG_PROVIDER`
- `EDGEX_CONF_DIR` is replaced by `EDGEX_CONFIG_DIR`

Signed-off-by: Felix Ting <felix@iotechsys.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) https://github.com/edgexfoundry/edgex-docs/pull/914

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Download this docker-compose file(https://github.com/edgexfoundry/edgex-compose/blob/main/docker-compose-no-secty.yml) and edit it to remove device-virtual
2. Run EdgeX Foundry with the docker-compose file
3. Download https://github.com/FelixTing/go-mod-bootstrap/tree/issue-399
4. Download device-virtual (https://github.com/edgexfoundry/device-virtual-go), edit go.mod to replace github.com/edgexfoundry/go-mod-bootstrap/v2 with the one downloaded in step 3. For example
```
replace github.com/edgexfoundry/go-mod-bootstrap/v2 => ../go-mod-bootstrap
```
5. Build a binary executable for device-virtual
```
make build
```
6. Set environment variables, for example:
```
export EDGEX_CONFIG_PROVIDER=consul.http://localhost:8500
export EDGEX_CONFIG_FILE=my-config.toml
```
7. Run device-virtual
8. Logs similar to the following are expected to appear:
```
level=INFO ts=2022-12-07T04:43:41.025805Z app=device-virtual source=variables.go:377 msg="Variables override of '-f/-file' by environment variable: EDGEX_CONFIG_FILE=my-config.toml"
level=INFO ts=2022-12-07T04:43:41.029159Z app=device-virtual source=variables.go:377 msg="Variables override of 'Configuration Provider Information' by environment variable: EDGEX_CONFIG_PROVIDER=consul.http://localhost:8500"

```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->