### PR TITLE
feat: Add go-mod-bootstrap hooks for JWT generation and verification

### DIFF
--- a/bootstrap/handlers/auth_middleware.go
+++ b/bootstrap/handlers/auth_middleware.go
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/secret"
+)
+
+// VaultAuthenticationHandlerFunc prefixes an existing HandlerFunc
+// with a Vault-based JWT authentication check.  Usage:
+//
+//  authenticationHook := handlers.NilAuthenticationHandlerFunc()
+//  if secret.IsSecurityEnabled() {
+//		lc := container.LoggingClientFrom(dic.Get)
+//      secretProvider := container.SecretProviderFrom(dic.Get)
+//      authenticationHook = handlers.VaultAuthenticationHandlerFunc(secretProvider, lc)
+//  }
+//  For optionally-authenticated requests
+//  r.HandleFunc("path", authenticationHook(handlerFunc)).Methods(http.MethodGet)
+//
+//  For unauthenticated requests
+//  r.HandleFunc("path", handlerFunc).Methods(http.MethodGet)
+//
+// For typical usage, it is preferred to use AutoConfigAuthenticationFunc which
+// will automatically select between a real and a fake JWT validation handler.
+func VaultAuthenticationHandlerFunc(secretProvider interfaces.SecretProvider, lc logger.LoggingClient) func(inner http.HandlerFunc) http.HandlerFunc {
+	return func(inner http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			authHeader := r.Header.Get("Authorization")
+			lc.Infof("Authorizing incoming call to '%s' via JWT (Authorization len=%d)", r.URL.Path, len(authHeader))
+			authParts := strings.Split(authHeader, " ")
+			if len(authParts) >= 2 && strings.EqualFold(authParts[0], "Bearer") {
+				token := authParts[1]
+				validToken, err := secretProvider.IsJWTValid(token)
+				if err != nil {
+					lc.Errorf("Error checking JWT validity: %v", err)
+					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+					return
+				} else if !validToken {
+					lc.Infof("Request to '%s' UNAUTHORIZED", r.URL.Path)
+					http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+					return
+				}
+				lc.Infof("Request to '%s' authorized", r.URL.Path)
+				inner(w, r)
+				return
+			}
+			lc.Errorf("Unable to parse JWT for call to '%s'; unauthorized", r.URL.Path)
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		}
+	}
+}
+
+// NilAuthenticationHandlerFunc just invokes a nested handler
+func NilAuthenticationHandlerFunc() func(inner http.HandlerFunc) http.HandlerFunc {
+	return func(inner http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			inner(w, r)
+		}
+	}
+}
+
+// AutoConfigAuthenticationFunc auto-selects between a HandlerFunc
+// wrapper that does authentication and a HandlerFunc wrapper that does not.
+// By default, JWT validation is enabled in secure mode
+// (i.e. when using a real secrets provider instead of a no-op stub)
+//
+// Set EDGEX_DISABLE_JWT_VALIDATION to 1, t, T, TRUE, true, or True
+// to disable JWT validation.  This might be wanted for an EdgeX
+// adopter that wanted to only validate JWT's at the proxy layer,
+// or as an escape hatch for a caller that cannot authenticate.
+func AutoConfigAuthenticationFunc(secretProvider interfaces.SecretProvider, lc logger.LoggingClient) func(inner http.HandlerFunc) http.HandlerFunc {
+	// Golang standard library treats an error as false
+	disableJWTValidation, _ := strconv.ParseBool(os.Getenv("EDGEX_DISABLE_JWT_VALIDATION"))
+	authenticationHook := NilAuthenticationHandlerFunc()
+	if secret.IsSecurityEnabled() && !disableJWTValidation {
+		authenticationHook = VaultAuthenticationHandlerFunc(secretProvider, lc)
+	}
+	return authenticationHook
+}

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2022 Intel Inc.
+ * Copyright (C) 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -29,6 +30,7 @@ import (
 	"github.com/edgexfoundry/go-mod-registry/v3/registry"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 )
@@ -56,6 +58,7 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 	lc := container.LoggingClientFrom(dic.Get)
 	config := container.ConfigurationFrom(dic.Get)
 	cb.registry = container.RegistryFrom(dic.Get)
+	jwtSecretProvider := secret.NewJWTSecretProvider(container.SecretProviderFrom(dic.Get))
 
 	for serviceKey, serviceInfo := range config.GetBootstrap().Clients {
 		var url string
@@ -73,22 +76,22 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 		case common.CoreDataServiceKey:
 			dic.Update(di.ServiceConstructorMap{
 				container.EventClientName: func(get di.Get) interface{} {
-					return clients.NewEventClient(url)
+					return clients.NewEventClient(url, jwtSecretProvider)
 				},
 			})
 		case common.CoreMetaDataServiceKey:
 			dic.Update(di.ServiceConstructorMap{
 				container.DeviceClientName: func(get di.Get) interface{} {
-					return clients.NewDeviceClient(url)
+					return clients.NewDeviceClient(url, jwtSecretProvider)
 				},
 				container.DeviceServiceClientName: func(get di.Get) interface{} {
-					return clients.NewDeviceServiceClient(url)
+					return clients.NewDeviceServiceClient(url, jwtSecretProvider)
 				},
 				container.DeviceProfileClientName: func(get di.Get) interface{} {
-					return clients.NewDeviceProfileClient(url)
+					return clients.NewDeviceProfileClient(url, jwtSecretProvider)
 				},
 				container.ProvisionWatcherClientName: func(get di.Get) interface{} {
-					return clients.NewProvisionWatcherClient(url)
+					return clients.NewProvisionWatcherClient(url, jwtSecretProvider)
 				},
 			})
 
@@ -115,7 +118,7 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 
 				lc.Infof("Using messaging for '%s' clients", serviceKey)
 			} else {
-				client = clients.NewCommandClient(url)
+				client = clients.NewCommandClient(url, jwtSecretProvider)
 			}
 
 			dic.Update(di.ServiceConstructorMap{
@@ -127,20 +130,20 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 		case common.SupportNotificationsServiceKey:
 			dic.Update(di.ServiceConstructorMap{
 				container.NotificationClientName: func(get di.Get) interface{} {
-					return clients.NewNotificationClient(url)
+					return clients.NewNotificationClient(url, jwtSecretProvider)
 				},
 				container.SubscriptionClientName: func(get di.Get) interface{} {
-					return clients.NewSubscriptionClient(url)
+					return clients.NewSubscriptionClient(url, jwtSecretProvider)
 				},
 			})
 
 		case common.SupportSchedulerServiceKey:
 			dic.Update(di.ServiceConstructorMap{
 				container.IntervalClientName: func(get di.Get) interface{} {
-					return clients.NewIntervalClient(url)
+					return clients.NewIntervalClient(url, jwtSecretProvider)
 				},
 				container.IntervalActionClientName: func(get di.Get) interface{} {
-					return clients.NewIntervalActionClient(url)
+					return clients.NewIntervalActionClient(url, jwtSecretProvider)
 				},
 			})
 

--- a/bootstrap/interfaces/mocks/SecretProvider.go
+++ b/bootstrap/interfaces/mocks/SecretProvider.go
@@ -85,6 +85,27 @@ func (_m *SecretProvider) GetSecret(path string, keys ...string) (map[string]str
 	return r0, r1
 }
 
+// GetSelfJWT provides a mock function with given fields:
+func (_m *SecretProvider) GetSelfJWT() (string, error) {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // HasSecret provides a mock function with given fields: path
 func (_m *SecretProvider) HasSecret(path string) (bool, error) {
 	ret := _m.Called(path)
@@ -99,6 +120,27 @@ func (_m *SecretProvider) HasSecret(path string) (bool, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// IsJWTValid provides a mock function with given fields: jwt
+func (_m *SecretProvider) IsJWTValid(jwt string) (bool, error) {
+	ret := _m.Called(jwt)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(jwt)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(jwt)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/bootstrap/interfaces/secret.go
+++ b/bootstrap/interfaces/secret.go
@@ -1,4 +1,16 @@
-package interfaces
+/*******************************************************************************
+ * Copyright (C) 2023 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/package interfaces
 
 import (
 	"time"
@@ -40,4 +52,10 @@ type SecretProvider interface {
 
 	// GetMetricsToRegister returns all metric objects that needs to be registered.
 	GetMetricsToRegister() map[string]interface{}
+
+	// GetSelfJWT returns an encoded JWT for the current identity-based secret store token
+	GetSelfJWT() (string, error)
+
+	// IsJWTValid evaluates a given JWT and returns a true/false if the JWT is valid (i.e. belongs to us and current) or not
+	IsJWTValid(jwt string) (bool, error)
 }

--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Intel Inc.
+ * Copyright 2020-2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -197,4 +197,17 @@ func (p *InsecureProvider) GetMetricsToRegister() map[string]interface{} {
 		secretsRequestedMetricName: p.securitySecretsRequested,
 		secretsStoredMetricName:    p.securitySecretsStored,
 	}
+}
+
+// GetSelfJWT returns an encoded JWT for the current identity-based secret store token
+func (p *InsecureProvider) GetSelfJWT() (string, error) {
+	// If security is disabled, return an empty string
+	// It is presumed HTTP invokers will not add an
+	// authorization token that is empty to outbound requests.
+	return "", nil
+}
+
+// IsJWTValid evaluates a given JWT and returns a true/false if the JWT is valid (i.e. belongs to us and current) or not
+func (p *InsecureProvider) IsJWTValid(jwt string) (bool, error) {
+	return true, nil
 }

--- a/bootstrap/secret/insecure_test.go
+++ b/bootstrap/secret/insecure_test.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2020 Intel Inc.
+ * Copyright 2020-2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -96,6 +96,21 @@ func TestInsecureProvider_GetAccessToken(t *testing.T) {
 	actualToken, err := target.GetAccessToken(TokenTypeConsul, "my-service-key")
 	require.NoError(t, err)
 	assert.Len(t, actualToken, 0)
+}
+
+func TestInsecureProvider_GetSelfJWT(t *testing.T) {
+	target := NewInsecureProvider(nil, logger.MockLogger{})
+	actualToken, err := target.GetSelfJWT()
+	require.NoError(t, err)
+	require.Equal(t, "", actualToken)
+}
+
+func TestInsecureProvider_IsJWTValid(t *testing.T) {
+	nullJWT := "eyJhbGciOiJOb25lIiwidHlwIjoiSldUIn0.e30."
+	target := NewInsecureProvider(nil, logger.MockLogger{})
+	result, err := target.IsJWTValid(nullJWT)
+	require.NoError(t, err)
+	require.Equal(t, true, result)
 }
 
 func TestInsecureProvider_ListPaths(t *testing.T) {

--- a/bootstrap/secret/jwtprovider.go
+++ b/bootstrap/secret/jwtprovider.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 Intel Corporation
+// Copyright (C) 2022-2023 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,7 +36,7 @@ func (self *jwtSecretProvider) AddAuthenticationData(req *http.Request) error {
 		return err
 	}
 
-	// Only add authorization header if we can non-empty token back
+	// Only add authorization header if we get non-empty token back
 	if len(jwt) > 0 {
 		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
 	}

--- a/bootstrap/secret/jwtprovider.go
+++ b/bootstrap/secret/jwtprovider.go
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package secret
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	clientInterfaces "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces"
+)
+
+type jwtSecretProvider struct {
+	secretProvider interfaces.SecretProvider
+}
+
+func NewJWTSecretProvider(secretProvider interfaces.SecretProvider) clientInterfaces.AuthenticationInjector {
+	return &jwtSecretProvider{
+		secretProvider: secretProvider,
+	}
+}
+
+func (self *jwtSecretProvider) AddAuthenticationData(req *http.Request) error {
+	if self.secretProvider == nil {
+		// Test cases or real code may invoke NewJWTSecretProvider(nil),
+		// though this is discouraged. In that case, just do nothing.
+		return nil
+	}
+
+	// Otherwise if there is a secret provider, get the JWT
+	jwt, err := self.secretProvider.GetSelfJWT()
+	if err != nil {
+		return err
+	}
+
+	// Only add authorization header if we can non-empty token back
+	if len(jwt) > 0 {
+		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", jwt))
+	}
+
+	return nil
+}

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2018 Dell Inc.
- * Copyright 2020 Intel Inc.
+ * Copyright 2020-2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -451,4 +451,14 @@ func (p *SecureProvider) GetMetricsToRegister() map[string]interface{} {
 		securityConsulTokensRequestedName: p.securityConsulTokensRequested,
 		securityConsulTokenDurationName:   p.securityConsulTokenDuration,
 	}
+}
+
+// GetSelfJWT returns an encoded JWT for the current identity-based secret store token
+func (p *SecureProvider) GetSelfJWT() (string, error) {
+	return p.secretClient.GetSelfJWT(p.serviceKey)
+}
+
+// IsJWTValid evaluates a given JWT and returns a true/false if the JWT is valid (i.e. belongs to us and current) or not
+func (p *SecureProvider) IsJWTValid(jwt string) (bool, error) {
+	return p.secretClient.IsJWTValid(jwt)
 }

--- a/di/container.go
+++ b/di/container.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
+ * Copyright 2020-2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -62,7 +63,9 @@
 //	}
 package di
 
-import "sync"
+import (
+	"sync"
+)
 
 type Get func(serviceName string) interface{}
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.2
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.3
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.20
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.22
 	github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.11
 	github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.0.0-dev.7

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/eclipse/paho.mqtt.golang v1.4.2 h1:66wOzfUHSSI1zamx7jR6yMEI5EuHnT1G6r
 github.com/eclipse/paho.mqtt.golang v1.4.2/go.mod h1:JGt0RsEwEX+Xa/agj90YJ9d9DH2b7upDZMK9HRbFvCA=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.3 h1:0Ew4PzLSFJ+sb7AYtvb9m1mRN45Sh0ELU1HdMCel5t8=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.0.0-dev.3/go.mod h1:ESOWI4GokQfQ3Bn2hGsdfOVx5idj7QEdCPT/SAQDd9M=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.20 h1:U1jnaIMecwReLJMnSibgwhlF8zDuSXbYjUbqjdDL/cE=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.20/go.mod h1:4lpZUM54ZareGU/yuAJvLEw0BoJ43SvCj1LO+gsKm9c=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.22 h1:8esqptBdtzS1iRNH0g1m4HRJF9tXebdd/q7wFo1W0rc=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.0.0-dev.22/go.mod h1:4lpZUM54ZareGU/yuAJvLEw0BoJ43SvCj1LO+gsKm9c=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.11 h1:f/ECYLJqXXuFrRcGzU6NzMrFoLASjfptCVlqujbVMKc=
 github.com/edgexfoundry/go-mod-messaging/v3 v3.0.0-dev.11/go.mod h1:FUzX+H9+aokoAHVnIkr997dKnRGpsGO98/thvcx1WR4=
 github.com/edgexfoundry/go-mod-registry/v3 v3.0.0-dev.3 h1:QgZF9f70Cwpvkjw3tP1aiVGHc+yNFJNzW6hO8pDs3fg=


### PR DESCRIPTION
This commit consumes the breaking change to go-mod-core-contracts
by injecting a Vault-issued JWT into all outgoing HTTP requests.

This commit presumes changes to security-secrestore-setup
to initialize Vault service identity and go-mod-secrets interface
changes to request and validate JWTs.  Adopting this change does
not force authentication on inbound requests, as authentication
must be enabled on a route-by-route basis in each EdgeX microservice.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
`make test`

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->