### PR TITLE
refactor!: Rename command line flags for the sake of consistency

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -374,7 +374,7 @@ func (cp *Processor) createProviderClient(
 
 // LoadFromFile attempts to read and unmarshal toml-based configuration into a configuration struct.
 func (cp *Processor) loadFromFile(config interface{}, configType string) error {
-	configDir := environment.GetConfDir(cp.lc, cp.flags.ConfigDirectory())
+	configDir := environment.GetConfigDir(cp.lc, cp.flags.ConfigDirectory())
 	profileDir := environment.GetProfileDir(cp.lc, cp.flags.Profile())
 	configFileName := environment.GetConfigFileName(cp.lc, cp.flags.ConfigFileName())
 

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -311,13 +311,13 @@ func GetStartupInfo(serviceKey string) StartupInfo {
 	return startup
 }
 
-// GetConfDir get the config directory value from a Variables variable value (if it exists)
+// GetConfigDir get the config directory value from a Variables variable value (if it exists)
 // or uses passed in value or default if previous result in blank.
-func GetConfDir(lc logger.LoggingClient, configDir string) string {
+func GetConfigDir(lc logger.LoggingClient, configDir string) string {
 	envValue := os.Getenv(envConfigDir)
 	if len(envValue) > 0 {
 		configDir = envValue
-		logEnvironmentOverride(lc, "-c/-confdir", envConfigDir, envValue)
+		logEnvironmentOverride(lc, "-cd/-configDir", envConfigDir, envValue)
 	}
 
 	if len(configDir) == 0 {
@@ -349,7 +349,7 @@ func GetConfigFileName(lc logger.LoggingClient, configFileName string) string {
 	envValue := os.Getenv(envConfigFile)
 	if len(envValue) > 0 {
 		configFileName = envValue
-		logEnvironmentOverride(lc, "-f/-file", envConfigFile, envValue)
+		logEnvironmentOverride(lc, "-cf/--configFile", envConfigFile, envValue)
 	}
 
 	return configFileName

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -152,7 +152,7 @@ func TestGetStartupInfo(t *testing.T) {
 	}
 }
 
-func TestGetConfDir(t *testing.T) {
+func TestGetConfigDir(t *testing.T) {
 	_, lc := initializeTest()
 
 	testCases := []struct {
@@ -175,7 +175,7 @@ func TestGetConfDir(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			actual := GetConfDir(lc, test.PassedInName)
+			actual := GetConfigDir(lc, test.PassedInName)
 			assert.Equal(t, test.ExpectedName, actual)
 		})
 	}

--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -85,12 +85,12 @@ func (d *Default) Parse(arguments []string) {
 	d.FlagSet.StringVar(&d.configProviderUrl, "cp", "", "")
 	d.FlagSet.BoolVar(&d.overwriteConfig, "overwrite", false, "")
 	d.FlagSet.BoolVar(&d.overwriteConfig, "o", false, "")
-	d.FlagSet.StringVar(&d.configFileName, "f", DefaultConfigFile, "")
-	d.FlagSet.StringVar(&d.configFileName, "file", DefaultConfigFile, "")
+	d.FlagSet.StringVar(&d.configFileName, "cf", DefaultConfigFile, "")
+	d.FlagSet.StringVar(&d.configFileName, "configFile", DefaultConfigFile, "")
 	d.FlagSet.StringVar(&d.profile, "profile", "", "")
 	d.FlagSet.StringVar(&d.profile, "p", "", ".")
-	d.FlagSet.StringVar(&d.configDir, "confdir", "", "")
-	d.FlagSet.StringVar(&d.configDir, "c", "", "")
+	d.FlagSet.StringVar(&d.configDir, "configDir", "", "")
+	d.FlagSet.StringVar(&d.configDir, "cd", "", "")
 	d.FlagSet.BoolVar(&d.useRegistry, "registry", false, "")
 	d.FlagSet.BoolVar(&d.useRegistry, "r", false, "")
 
@@ -148,9 +148,9 @@ func (d *Default) helpCallback() {
 			"    -o, --overwrite                 Overwrite configuration in provider with local configuration\n"+
 			"                                    *** Use with cation *** Use will clobber existing settings in provider,\n"+
 			"                                    problematic if those settings were edited by hand intentionally\n"+
-			"    -f, --file <name>               Indicates name of the local configuration file. Defaults to configuration.toml\n"+
+			"    -cf, --configFile <name>        Indicates name of the local configuration file. Defaults to configuration.toml\n"+
 			"    -p, --profile <name>            Indicate configuration profile other than default\n"+
-			"    -c, --confdir                   Specify local configuration directory\n"+
+			"    -cd, --configDir                Specify local configuration directory\n"+
 			"    -r, --registry                  Indicates service should use Registry.\n"+
 			"%s\n"+
 			"Common Options:\n"+

--- a/bootstrap/flags/flags_test.go
+++ b/bootstrap/flags/flags_test.go
@@ -37,8 +37,8 @@ func TestNewAllFlags(t *testing.T) {
 			"-o",
 			"-r",
 			"-p=" + expectedProfile,
-			"-c=" + expectedConfigDirectory,
-			"-f=" + expectedFileName,
+			"-cd=" + expectedConfigDirectory,
+			"-cf=" + expectedFileName,
 		},
 	)
 
@@ -90,23 +90,23 @@ func TestNewOverrideConfigProvider(t *testing.T) {
 
 func TestDashR(t *testing.T) {
 	expectedConfigDirectory := "/foo/ba-r/"
-	actual := newSUT([]string{"-confdir", "/foo/ba-r/"})
+	actual := newSUT([]string{"-configDir", "/foo/ba-r/"})
 
 	assert.Equal(t, expectedConfigDirectory, actual.ConfigDirectory())
 }
 
-func TestConfDirEquals(t *testing.T) {
+func TestConfigDirEquals(t *testing.T) {
 	expectedConfigDirectory := "/foo/ba-r/"
-	actual := newSUT([]string{"-confdir=/foo/ba-r/"})
+	actual := newSUT([]string{"-configDir=/foo/ba-r/"})
 
 	assert.Equal(t, expectedConfigDirectory, actual.ConfigDirectory())
 }
 
-func TestConfCommonScenario(t *testing.T) {
+func TestConfigCommonScenario(t *testing.T) {
 	expectedConfigProviderUrl := "consul.http://edgex-core-consul:8500"
 	expectedConfigDirectory := "/res"
 
-	actual := newSUT([]string{"-cp=consul.http://edgex-core-consul:8500", "--registry", "--confdir=/res"})
+	actual := newSUT([]string{"-cp=consul.http://edgex-core-consul:8500", "--registry", "--configDir=/res"})
 
 	assert.Equal(t, expectedConfigProviderUrl, actual.ConfigProviderUrl())
 	assert.True(t, actual.UseRegistry())


### PR DESCRIPTION
BREAKING CHANGE:
- `-c/--confdir` to `-cd/--configDir`
- `-f/--file` to `-cf/--configFile`

Signed-off-by: Felix Ting <felix@iotechsys.com>
Signed-off-by: Ginny Guan <ginny@iotechsys.com>

related issue: https://github.com/edgexfoundry/edgex-go/issues/4248

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?) https://github.com/edgexfoundry/edgex-docs/pull/916


## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core-data with `-cd/--configDir` and `-cf/--configFile`
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->