### PR TITLE
refactor!: Rework MessageBus configuration for all services to use consistently

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -25,7 +25,11 @@ import (
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/types"
 )
 
-const DefaultHttpProtocol = "http"
+const (
+	DefaultHttpProtocol          = "http"
+	MessageBusPublishTopicPrefix = "PublishTopicPrefix"
+	MessageBusSubscribeTopic     = "SubscribeTopic"
+)
 
 // ServiceInfo contains configuration settings necessary for the basic operation of any EdgeX service.
 type ServiceInfo struct {
@@ -191,12 +195,14 @@ type BootstrapConfiguration struct {
 	Config       ConfigProviderInfo
 	Registry     RegistryInfo
 	SecretStore  SecretStoreInfo
-	MessageQueue MessageBusInfo
+	MessageBus   MessageBusInfo
 	ExternalMQTT ExternalMQTTInfo
 }
 
-// MessageBusInfo provides parameters related to connecting to a message bus as a publisher
+// MessageBusInfo provides parameters related to connecting to the EdgeX MessageBus
 type MessageBusInfo struct {
+	// Disabled indicates if the use of the EdgeX MessageBus is disabled.
+	Disabled bool
 	// Indicates the message bus implementation to use, i.e. zero, mqtt, redisstreams...
 	Type string
 	// Protocol indicates the protocol to use when accessing the message bus.
@@ -205,28 +211,20 @@ type MessageBusInfo struct {
 	Host string
 	// Port defines the port on which to access the message bus.
 	Port int
-	// PublishTopicPrefix indicates the topic prefix the data is published to.
-	PublishTopicPrefix string
-	// SubscribeTopic indicates the topic in which to subscribe.
-	SubscribeTopic string
 	// AuthMode specifies the type of secure connection to the message bus which are 'none', 'usernamepassword'
 	// 'clientcert' or 'cacert'. Not all option supported by each implementation.
-	// ZMQ doesn't support any Authmode beyond 'none', RedisStreams only supports 'none' & 'usernamepassword'
-	// while MQTT supports all options.
+	// RedisStreams only supports 'none' & 'usernamepassword' while MQTT and NATS support all options.
 	AuthMode string
 	// SecretName is the name of the secret in the SecretStore that contains the Auth Credentials. The credential are
 	// dynamically loaded using this name and store the Option property below where the implementation expected to
 	// find them.
 	SecretName string
+	// Topics allows MessageBusInfo to be more flexible with respect to topics.
+	Topics map[string]string
 	// Provides additional configuration properties which do not fit within the existing field.
-	// Typically the key is the name of the configuration property and the value is a string representation of the
+	// Typically, the key is the name of the configuration property and the value is a string representation of the
 	// desired value for the configuration property.
 	Optional map[string]string
-	// SubscribeEnabled indicates whether enable the subscription to the Message Queue
-	SubscribeEnabled bool
-	// Topics allows MessageBusInfo to be more flexible with respect to topics.
-	// TODO: move PublishTopicPrefix and SubscribeTopic to Topics in EdgeX 3.0
-	Topics map[string]string
 }
 
 type ExternalMQTTInfo struct {


### PR DESCRIPTION
BREAKING CHANGE: MessageQueue renamed to MessageBus and fields changed. See v3 Migration guide.

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
 TBD

## Testing Instructions
See follow on PRs for edgex-go

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->