### PR TITLE
refactor!: Replace SecretStore service config with default values and overrides

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"syscall"
 
-	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/flags"
@@ -85,7 +85,7 @@ func RunAndReturnWaitGroup(
 	serviceKey string,
 	configStem string,
 	serviceConfig interfaces.Configuration,
-	configUpdated bootstrapConfig.UpdatedStream,
+	configUpdated config.UpdatedStream,
 	startupTimer startup.Timer,
 	dic *di.Container,
 	useSecretProvider bool,
@@ -121,7 +121,7 @@ func RunAndReturnWaitGroup(
 	// The SecretProvider is initialized and placed in the DIS as part of processing the configuration due
 	// to the need for it to be used to get Access Token for the Configuration Provider and having to wait to
 	// initialize it until after the configuration is loaded from file.
-	configProcessor := bootstrapConfig.NewProcessor(commonFlags, envVars, startupTimer, ctx, &wg, configUpdated, dic)
+	configProcessor := config.NewProcessor(commonFlags, envVars, startupTimer, ctx, &wg, configUpdated, dic)
 	if err := configProcessor.Process(serviceKey, configStem, serviceConfig, secretProvider); err != nil {
 		fatalError(err, lc)
 	}

--- a/bootstrap/handlers/externalmqtt.go
+++ b/bootstrap/handlers/externalmqtt.go
@@ -39,7 +39,7 @@ func (e *ExternalMQTT) BootstrapHandler(ctx context.Context, wg *sync.WaitGroup,
 	topics := brokerConfig.SubscribeTopics
 	// TODO: remove first check and update error log in EdgeX 3.0
 	if len(strings.TrimSpace(topics)) == 0 && len(brokerConfig.Topics) == 0 {
-		lc.Errorf("missing SubscribeTopics and/or Topics for external MQTT connection. Must be present in [MessageQueue.External] section")
+		lc.Errorf("missing SubscribeTopics and/or Topics for external MQTT connection. Must be present in [ExternalMqtt] section")
 		return false
 	}
 

--- a/bootstrap/secret/insecure_test.go
+++ b/bootstrap/secret/insecure_test.go
@@ -306,3 +306,39 @@ func TestInsecureProvider_DeregisterSecretUpdatedCallback(t *testing.T) {
 		})
 	}
 }
+
+type TestConfig struct {
+	InsecureSecrets bootstrapConfig.InsecureSecrets
+}
+
+func (t TestConfig) UpdateFromRaw(_ interface{}) bool {
+	panic("implement me")
+}
+
+func (t TestConfig) EmptyWritablePtr() interface{} {
+	panic("implement me")
+}
+
+func (t TestConfig) UpdateWritableFromRaw(_ interface{}) bool {
+	panic("implement me")
+}
+
+func (t TestConfig) GetBootstrap() bootstrapConfig.BootstrapConfiguration {
+	return bootstrapConfig.BootstrapConfiguration{}
+}
+
+func (t TestConfig) GetLogLevel() string {
+	panic("implement me")
+}
+
+func (t TestConfig) GetRegistryInfo() bootstrapConfig.RegistryInfo {
+	panic("implement me")
+}
+
+func (t TestConfig) GetInsecureSecrets() bootstrapConfig.InsecureSecrets {
+	return t.InsecureSecrets
+}
+
+func (t TestConfig) GetTelemetryInfo() *bootstrapConfig.TelemetryInfo {
+	panic("implement me")
+}

--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -21,6 +21,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-secrets/v3/secrets"
@@ -28,7 +30,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
-	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/token/authtokenloader"
@@ -47,6 +48,7 @@ const (
 // NewSecretProvider creates a new fully initialized the Secret Provider.
 func NewSecretProvider(
 	configuration interfaces.Configuration,
+	envVars *environment.Variables,
 	ctx context.Context,
 	startupTimer startup.Timer,
 	dic *di.Container,
@@ -62,7 +64,10 @@ func NewSecretProvider(
 
 		lc.Info("Creating SecretClient")
 
-		secretStoreConfig := configuration.GetBootstrap().SecretStore
+		secretStoreConfig, err := BuildSecretStoreConfig(serviceKey, envVars, lc)
+		if err != nil {
+			return nil, err
+		}
 
 		for startupTimer.HasNotElapsed() {
 			var secretConfig types.SecretConfig
@@ -82,7 +87,7 @@ func NewSecretProvider(
 
 			secretConfig, err = getSecretConfig(secretStoreConfig, tokenLoader, runtimeTokenLoader, serviceKey, lc)
 			if err == nil {
-				secureProvider := NewSecureProvider(ctx, configuration, lc, tokenLoader, runtimeTokenLoader, serviceKey)
+				secureProvider := NewSecureProvider(ctx, secretStoreConfig, lc, tokenLoader, runtimeTokenLoader, serviceKey)
 				var secretClient secrets.SecretClient
 
 				lc.Info("Attempting to create secret client")
@@ -137,9 +142,27 @@ func NewSecretProvider(
 	return provider, nil
 }
 
+// BuildSecretStoreConfig is public helper function that builds the SecretStore configuration
+// from default values and  environment override.
+func BuildSecretStoreConfig(serviceKey string, envVars *environment.Variables, lc logger.LoggingClient) (*config.SecretStoreInfo, error) {
+	configWrapper := struct {
+		SecretStore config.SecretStoreInfo
+	}{
+		SecretStore: config.NewSecretStoreInfo(serviceKey),
+	}
+
+	count, err := envVars.OverrideConfiguration(&configWrapper)
+	if err != nil {
+		return nil, fmt.Errorf("failed to override SecretStore information: %v", err)
+	}
+
+	lc.Infof("SecretStore information created with %d overrides applied", count)
+	return &configWrapper.SecretStore, nil
+}
+
 // getSecretConfig creates a SecretConfig based on the SecretStoreInfo configuration properties.
 // If a token file is present it will override the Authentication.AuthToken value.
-func getSecretConfig(secretStoreInfo config.SecretStoreInfo,
+func getSecretConfig(secretStoreInfo *config.SecretStoreInfo,
 	tokenLoader authtokenloader.AuthTokenLoader,
 	runtimeTokenLoader runtimetokenprovider.RuntimeTokenProvider,
 	serviceKey string,

--- a/bootstrap/secret/secure_test.go
+++ b/bootstrap/secret/secure_test.go
@@ -20,16 +20,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	mock2 "github.com/stretchr/testify/mock"
-
-	bootstrapConfig "github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg"
 	mocks2 "github.com/edgexfoundry/go-mod-secrets/v3/pkg/token/authtokenloader/mocks"
 	runtimeTokenMock "github.com/edgexfoundry/go-mod-secrets/v3/pkg/token/runtimetokenprovider/mocks"
-	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-secrets/v3/secrets"
 	"github.com/edgexfoundry/go-mod-secrets/v3/secrets/mocks"
 
@@ -61,7 +60,8 @@ func TestSecureProvider_GetSecrets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewSecureProvider(context.Background(), tc.Config, logger.MockLogger{}, nil, nil, "testService")
+
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 			target.SetClient(tc.Client)
 			actual, err := target.GetSecret(tc.Path, tc.Keys...)
 			if tc.ExpectError {
@@ -82,7 +82,7 @@ func TestSecureProvider_GetSecrets_Cached(t *testing.T) {
 	// Use the Once method so GetSecrets can be changed below
 	mock.On("GetSecrets", "redis", "username", "password").Return(expected, nil).Once()
 
-	target := NewSecureProvider(context.Background(), nil, logger.MockLogger{}, nil, nil, "testService")
+	target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 	target.SetClient(mock)
 
 	actual, err := target.GetSecret("redis", "username", "password")
@@ -109,7 +109,7 @@ func TestSecureProvider_GetSecrets_Cached_Invalidated(t *testing.T) {
 	mock.On("GetSecrets", "redis", "username", "password").Return(expected, nil).Once()
 	mock.On("StoreSecrets", "redis", expected).Return(nil)
 
-	target := NewSecureProvider(context.Background(), nil, logger.MockLogger{}, nil, nil, "testService")
+	target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 	target.SetClient(mock)
 
 	actual, err := target.GetSecret("redis", "username", "password")
@@ -146,7 +146,7 @@ func TestSecureProvider_StoreSecrets_Secure(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewSecureProvider(context.Background(), nil, logger.MockLogger{}, nil, nil, "testService")
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 			target.SetClient(tc.Client)
 
 			err := target.StoreSecret(tc.Path, input)
@@ -165,7 +165,7 @@ func TestSecureProvider_SecretsLastUpdated(t *testing.T) {
 	mock := &mocks.SecretClient{}
 	mock.On("StoreSecrets", "redis", input).Return(nil)
 
-	target := NewSecureProvider(context.Background(), nil, logger.MockLogger{}, nil, nil, "testService")
+	target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 	target.SetClient(mock)
 
 	previous := target.SecretsLastUpdated()
@@ -177,7 +177,7 @@ func TestSecureProvider_SecretsLastUpdated(t *testing.T) {
 }
 
 func TestSecureProvider_SecretsUpdated(t *testing.T) {
-	target := NewSecureProvider(context.Background(), nil, logger.MockLogger{}, nil, nil, "testService")
+	target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 	previous := target.SecretsLastUpdated()
 	time.Sleep(1 * time.Second)
 	target.SecretsUpdated()
@@ -211,15 +211,15 @@ func TestSecureProvider_DefaultTokenExpiredCallback(t *testing.T) {
 		{"Same Token", sameTokenFile, expiredToken, expiredToken, false},
 	}
 
+	lc := logger.NewMockClient()
+	envVars := environment.NewVariables(lc)
+	secretStore, err := BuildSecretStoreConfig("unit-test", envVars, lc)
+	require.NoError(t, err)
+
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			config := TestConfig{
-				SecretStore: bootstrapConfig.SecretStoreInfo{
-					TokenFile: tc.TokenFile,
-				},
-			}
-
-			target := NewSecureProvider(context.Background(), config, logger.MockLogger{}, mockTokenLoader, nil, "testService")
+			secretStore.TokenFile = tc.TokenFile
+			target := NewSecureProvider(context.Background(), secretStore, lc, mockTokenLoader, nil, "testService")
 			actualToken, actualRetry := target.DefaultTokenExpiredCallback(tc.ExpiredToken)
 			assert.Equal(t, tc.ExpectedToken, actualToken)
 			assert.Equal(t, tc.ExpectedRetry, actualRetry)
@@ -250,20 +250,7 @@ func TestSecureProvider_RuntimeTokenExpiredCallback(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			config := TestConfig{
-				SecretStore: bootstrapConfig.SecretStoreInfo{
-					RuntimeTokenProvider: types.RuntimeTokenProviderInfo{
-						Enabled:        true,
-						Protocol:       "https",
-						Host:           "provider.test.com",
-						Port:           12345,
-						TrustDomain:    "mydomain",
-						EndpointSocket: "/tmp/edgex/socket",
-					},
-				},
-			}
-
-			target := NewSecureProvider(context.Background(), config, logger.MockLogger{}, nil, mockRuntimeTokenProvider, tc.TestService)
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, mockRuntimeTokenProvider, tc.TestService)
 			actualToken, actualRetry := target.RuntimeTokenExpiredCallback(tc.ExpiredToken)
 			assert.Equal(t, tc.ExpectedToken, actualToken)
 			assert.Equal(t, tc.ExpectedRetry, actualRetry)
@@ -288,7 +275,7 @@ func TestSecureProvider_GetAccessToken(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			target := NewSecureProvider(context.Background(), TestConfig{}, logger.MockLogger{}, nil, nil, "testService")
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 			target.SetClient(mock)
 
 			actualToken, err := target.GetAccessToken(test.tokenType, testServiceKey)
@@ -321,7 +308,7 @@ func TestSecureProvider_seedSecrets(t *testing.T) {
 		{"Store Error", allGood, "", true, "1 error occurred:\n\t* failed to store secret for 'auth': store failed\n\n"},
 	}
 
-	target := NewSecureProvider(context.Background(), TestConfig{}, logger.MockLogger{}, nil, nil, "testService")
+	target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -374,7 +361,7 @@ func TestSecureProvider_HasSecrets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewSecureProvider(context.Background(), TestConfig{}, logger.MockLogger{}, nil, nil, "testService")
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 			target.SetClient(tc.Client)
 			actual, err := target.HasSecret(tc.Path)
 
@@ -406,7 +393,7 @@ func TestSecureProvider_ListSecretPathsSecrets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewSecureProvider(context.Background(), tc.Config, logger.MockLogger{}, nil, nil, "testService")
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.MockLogger{}, nil, nil, "testService")
 			target.SetClient(tc.Client)
 			actual, err := target.ListSecretPaths()
 			if tc.ExpectError {
@@ -439,7 +426,7 @@ func TestSecureProvider_SecretUpdatedAtPath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			callbackCalled = false
-			target := NewSecureProvider(context.Background(), tc.Config, logger.NewMockClient(), nil, nil, "testService")
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.NewMockClient(), nil, nil, "testService")
 
 			if tc.Callback != nil {
 				target.registeredSecretCallbacks[tc.Path] = tc.Callback
@@ -464,7 +451,7 @@ func TestSecureProvider_RegisteredSecretUpdatedCallback(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewSecureProvider(context.Background(), tc.Config, logger.NewMockClient(), nil, nil, "testService")
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.NewMockClient(), nil, nil, "testService")
 			err := target.RegisteredSecretUpdatedCallback(tc.Path, tc.Callback)
 			assert.NoError(t, err)
 
@@ -489,7 +476,7 @@ func TestSecureProvider_DeregisterSecretUpdatedCallback(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewSecureProvider(context.Background(), tc.Config, logger.NewMockClient(), nil, nil, "testService")
+			target := NewSecureProvider(context.Background(), secretStoreConfig(t), logger.NewMockClient(), nil, nil, "testService")
 
 			// Register a path.
 			err := target.RegisteredSecretUpdatedCallback(tc.Path, tc.Callback)
@@ -500,4 +487,12 @@ func TestSecureProvider_DeregisterSecretUpdatedCallback(t *testing.T) {
 			assert.Empty(t, target.registeredSecretCallbacks)
 		})
 	}
+}
+
+func secretStoreConfig(t *testing.T) *config.SecretStoreInfo {
+	lc := logger.NewMockClient()
+	envVars := environment.NewVariables(lc)
+	config, err := BuildSecretStoreConfig("unit-test", envVars, lc)
+	require.NoError(t, err)
+	return config
 }

--- a/config/types.go
+++ b/config/types.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
-
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/types"
+	"github.com/edgexfoundry/go-mod-secrets/v3/secrets"
 )
 
 const (
@@ -159,6 +159,35 @@ type SecretStoreInfo struct {
 	RuntimeTokenProvider types.RuntimeTokenProviderInfo
 }
 
+func NewSecretStoreInfo(serviceKey string) SecretStoreInfo {
+	return SecretStoreInfo{
+		Type:                    secrets.Vault,
+		Protocol:                "http",
+		Host:                    "localhost",
+		Port:                    8200,
+		Path:                    serviceKey,
+		TokenFile:               fmt.Sprintf("/tmp/edgex/secrets/%s/secrets-token.json", serviceKey),
+		DisableScrubSecretsFile: false,
+		Namespace:               "",
+		RootCaCertPath:          "",
+		ServerName:              "",
+		SecretsFile:             "",
+		Authentication: types.AuthenticationInfo{
+			AuthType:  "X-Vault-Token",
+			AuthToken: "",
+		},
+		RuntimeTokenProvider: types.RuntimeTokenProviderInfo{
+			Enabled:         false,
+			Protocol:        "https",
+			Host:            "localhost",
+			Port:            59841,
+			TrustDomain:     "edgexfoundry.org",
+			EndpointSocket:  "/tmp/edgex/secrets/spiffe/public/api.sock",
+			RequiredSecrets: "redisdb",
+		},
+	}
+}
+
 type Database struct {
 	Type    string
 	Timeout int
@@ -194,7 +223,6 @@ type BootstrapConfiguration struct {
 	Service      ServiceInfo
 	Config       ConfigProviderInfo
 	Registry     RegistryInfo
-	SecretStore  SecretStoreInfo
 	MessageBus   MessageBusInfo
 	ExternalMQTT ExternalMQTTInfo
 }


### PR DESCRIPTION
BREAKING CHANGE: SecretStore config no longer in service configuration file. Changes must be done via use of environment variable overrides of default values

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  TBD

## Testing Instructions
Build core data with this branch
Run secure EdgeX stack, store core data container and remove core data config from Consul
Run core data locally with DEBUG logging and SecretStore enabled.
```
sudo EDGEX_SECURITY_SECRET_STORE=true WRITABLE_LOGLEVEL=DEBUG ./core-data -cp -r
```
Verify core data bootstraps successfully and is receiving event from MessageBus
Verify core data config loaded from file and pushed to Consul 
Verify core data config in Consul no longer contains SecretStore section
Restart core data
Verify core data config loaded from Consul, never from file. 

More extensive testing will occur when edgex-go consumes these changes.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->