### PR TITLE
feat!: load common configuration

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -89,6 +89,7 @@ func RunAndReturnWaitGroup(
 	startupTimer startup.Timer,
 	dic *di.Container,
 	useSecretProvider bool,
+	serviceType string,
 	handlers []interfaces.BootstrapHandler) (*sync.WaitGroup, Deferred, bool) {
 
 	var err error
@@ -122,7 +123,7 @@ func RunAndReturnWaitGroup(
 	// to the need for it to be used to get Access Token for the Configuration Provider and having to wait to
 	// initialize it until after the configuration is loaded from file.
 	configProcessor := config.NewProcessor(commonFlags, envVars, startupTimer, ctx, &wg, configUpdated, dic)
-	if err := configProcessor.Process(serviceKey, configStem, serviceConfig, secretProvider); err != nil {
+	if err := configProcessor.Process(serviceKey, serviceType, configStem, serviceConfig, secretProvider); err != nil {
 		fatalError(err, lc)
 	}
 
@@ -208,6 +209,7 @@ func Run(
 	startupTimer startup.Timer,
 	dic *di.Container,
 	useSecretProvider bool,
+	serviceType string,
 	handlers []interfaces.BootstrapHandler) {
 
 	wg, deferred, success := RunAndReturnWaitGroup(
@@ -221,6 +223,7 @@ func Run(
 		startupTimer,
 		dic,
 		useSecretProvider,
+		serviceType,
 		handlers,
 	)
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
- * Copyright 2020 Intel Inc.
+ * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -88,7 +88,7 @@ func RunAndReturnWaitGroup(
 	configUpdated config.UpdatedStream,
 	startupTimer startup.Timer,
 	dic *di.Container,
-	useSecretProvider bool,
+	useSecretProvider bool, // TODO: remove useSecretProvider and use serviceType in place with its constant
 	serviceType string,
 	handlers []interfaces.BootstrapHandler) (*sync.WaitGroup, Deferred, bool) {
 

--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -14,8 +14,24 @@
 package config
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/flags"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/edgexfoundry/go-mod-configuration/v3/configuration"
+	"github.com/edgexfoundry/go-mod-configuration/v3/configuration/mocks"
+	"github.com/edgexfoundry/go-mod-configuration/v3/pkg/types"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"sync"
 	"testing"
 )
 
@@ -91,4 +107,238 @@ func TestGetSecretPathsChanged(t *testing.T) {
 			assert.Equal(t, tc.UpdatedPaths, updatedPaths)
 		})
 	}
+}
+
+func TestLoadCommonConfig(t *testing.T) {
+	serviceKey := "test-service"
+	getAccessToken := func() (string, error) {
+		return "", nil
+	}
+	serviceConfig := ConfigurationMockStruct{
+		Writable: WritableInfo{
+			LogLevel: "INFO",
+		},
+		Registry: config.RegistryInfo{
+			Host: "localhost",
+			Port: 8500,
+			Type: "consul",
+		},
+	}
+
+	appConfig := ConfigurationMockStruct{
+		Writable: WritableInfo{
+			StoreAndForward: StoreAndForwardInfo{
+				Enabled:       false,
+				RetryInterval: "5m",
+				MaxRetryCount: 10,
+			},
+		},
+		Trigger: TriggerInfo{
+			Type: "edgex-messagebus",
+		},
+	}
+
+	deviceConfig := ConfigurationMockStruct{
+		Writable: WritableInfo{
+			Telemetry: config.TelemetryInfo{
+				Metrics: map[string]bool{"EventsSent": false, "ReadingsSent": true},
+			},
+		},
+	}
+
+	tests := []struct {
+		Name                 string
+		serviceConfig        *ConfigurationMockStruct
+		serviceType          string
+		serviceTypeConfig    *ConfigurationMockStruct
+		providerClientErr    error
+		isAlive              bool
+		isCommonConfigReady  []byte
+		commonConfigReadyErr error
+		getConfigErr         error
+		expectedErr          error
+	}{
+		{"Valid - core service", &serviceConfig, config.ServiceTypeOther, nil,
+			nil, true, []byte("true"), nil, nil, nil},
+		{"Valid - app service", &serviceConfig, config.ServiceTypeApp, &appConfig,
+			nil, true, []byte("true"), nil, nil, nil},
+		{"Valid - device service", &serviceConfig, config.ServiceTypeDevice, &deviceConfig,
+			nil, true, []byte("true"), nil, nil, nil},
+		{"Invalid - config provider not alive", &serviceConfig, config.ServiceTypeOther, nil,
+			nil, false, []byte("false"), nil, nil, errors.New("configuration provider is not available")},
+		{"Invalid - common config not ready", &serviceConfig, config.ServiceTypeOther, nil,
+			nil, true, []byte("false"), nil, nil, errors.New("common config is not loaded")},
+		{"Invalid - common config not ready error", &serviceConfig, config.ServiceTypeOther, nil,
+			nil, true, []byte("false"), errors.New("config provider not available"), nil, errors.New("failed to retrieve common config value IsCommonConfigReady: config provider not available")},
+		{"Valid - core service", &serviceConfig, config.ServiceTypeOther, nil,
+			nil, true, []byte("true"), nil, errors.New("configuration not found"), errors.New("failed to load the common configuration for all services: configuration not found")},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.Name, func(t *testing.T) {
+			// create parameters for the processor
+			f := flags.New()
+			f.Parse(nil)
+			mockLogger := logger.MockLogger{}
+			env := environment.NewVariables(mockLogger)
+			timer := startup.NewStartUpTimer(serviceKey)
+			ctx, cancel := context.WithCancel(context.Background())
+
+			wg := sync.WaitGroup{}
+			dic := di.NewContainer(di.ServiceConstructorMap{
+				container.LoggingClientInterfaceName: func(get di.Get) interface{} { return mockLogger },
+			})
+			// create the processor
+			proc := NewProcessor(f, env, timer, ctx, &wg, nil, dic)
+			// set up mocks
+			providerClientMock := &mocks.Client{}
+			providerClientCreator := func(logger.LoggingClient,
+				string,
+				string,
+				types.GetAccessTokenCallback,
+				types.ServiceConfig) (configuration.Client, error) {
+				return providerClientMock, tc.providerClientErr
+			}
+			providerClientMock.On("IsAlive").Return(tc.isAlive)
+			serviceConfigMock := ConfigurationMockStruct{}
+			if tc.isAlive {
+				providerClientMock.On("GetConfigurationValue", "IsCommonConfigReady").Return(tc.isCommonConfigReady, tc.commonConfigReadyErr)
+			}
+			ccReady, err := strconv.ParseBool(string(tc.isCommonConfigReady))
+			require.NoError(t, err)
+			if ccReady {
+				providerClientMock.On("GetConfiguration", &serviceConfigMock).Return(tc.serviceConfig, tc.getConfigErr).Once()
+			}
+			if tc.serviceType == config.ServiceTypeApp || tc.serviceType == config.ServiceTypeDevice {
+				providerClientMock.On("GetConfiguration", &serviceConfigMock).Return(tc.serviceTypeConfig, tc.getConfigErr).Once()
+			}
+			// call load common config
+			err = proc.loadCommonConfig(common.ConfigStemAll, getAccessToken, &ProviderInfo{}, &serviceConfigMock, tc.serviceType, providerClientCreator)
+			// make assertions
+			providerClientMock.AssertExpectations(t)
+			require.NotNil(t, cancel)
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+				assert.NotNil(t, serviceConfigMock.Writable.LogLevel)
+				switch tc.serviceType {
+				case config.ServiceTypeApp:
+					assert.False(t, serviceConfigMock.Writable.StoreAndForward.Enabled)
+					assert.NotEmpty(t, serviceConfigMock.Writable.StoreAndForward.RetryInterval)
+					assert.NotZero(t, serviceConfigMock.Writable.StoreAndForward.MaxRetryCount)
+				case config.ServiceTypeDevice:
+					assert.False(t, serviceConfigMock.Writable.Telemetry.Metrics["EventsSent"])
+					assert.True(t, serviceConfigMock.Writable.Telemetry.Metrics["ReadingsSent"])
+				}
+				return
+			}
+			assert.Equal(t, err, tc.expectedErr)
+		})
+	}
+}
+
+func TestMergeConfigs(t *testing.T) {
+	// create the service config
+	serviceConfig := ConfigurationMockStruct{
+		Writable: WritableInfo{
+			LogLevel: "INFO",
+		},
+		Registry: config.RegistryInfo{
+			Host: "localhost",
+			Port: 8500,
+			Type: "consul",
+		},
+	}
+	require.NotEmpty(t, serviceConfig.Writable.LogLevel)
+	require.NotEmpty(t, serviceConfig.Registry.Host)
+	require.NotZero(t, serviceConfig.Registry.Port)
+	require.NotEmpty(t, serviceConfig.Registry.Type)
+
+	// create the app config
+	appConfig := ConfigurationMockStruct{
+		Writable: WritableInfo{
+			StoreAndForward: StoreAndForwardInfo{
+				Enabled:       false,
+				RetryInterval: "5m",
+				MaxRetryCount: 10,
+			},
+		},
+		Trigger: TriggerInfo{
+			Type: "edgex-messagebus",
+		},
+	}
+	require.False(t, appConfig.Writable.StoreAndForward.Enabled)
+	require.NotEmpty(t, appConfig.Writable.StoreAndForward.RetryInterval)
+	require.NotZero(t, appConfig.Writable.StoreAndForward.MaxRetryCount)
+	require.NotEmpty(t, appConfig.Trigger.Type)
+
+	// merge the configs
+	err := mergeConfigs(&serviceConfig, &appConfig)
+	require.NoError(t, err)
+
+	// verify values
+	assert.False(t, serviceConfig.Writable.StoreAndForward.Enabled)
+	assert.NotEmpty(t, serviceConfig.Writable.StoreAndForward.RetryInterval)
+	assert.NotZero(t, serviceConfig.Writable.StoreAndForward.MaxRetryCount)
+	assert.NotEmpty(t, serviceConfig.Trigger.Type)
+}
+
+func TestMergeMaps(t *testing.T) {
+	destMap := map[string]any{
+		"Writable": WritableInfo{
+			StoreAndForward: StoreAndForwardInfo{
+				Enabled:       false,
+				RetryInterval: "5m",
+				MaxRetryCount: 10,
+			},
+		},
+		"Registry": config.RegistryInfo{
+			Host: "localhost",
+			Port: 8500,
+			Type: "consul",
+		},
+		"Service":             config.ServiceInfo{},
+		"HttpServer":          HttpConfig{},
+		"MessageBus":          config.MessageBusInfo{},
+		"Trigger":             TriggerInfo{},
+		"ApplicationSettings": nil,
+		"Clients":             nil,
+	}
+	srcMap := map[string]any{
+		"Writable": WritableInfo{
+			StoreAndForward: StoreAndForwardInfo{
+				Enabled:       false,
+				RetryInterval: "5m",
+				MaxRetryCount: 10,
+			},
+		},
+		"Trigger": TriggerInfo{
+			Type: "edgex-messagebus",
+		},
+	}
+	mergeMaps(destMap, srcMap)
+
+	for key, value := range destMap {
+		if key == "StoreAndForwardInfo" || key == "Trigger" {
+			assert.NotEmpty(t, value)
+		}
+	}
+}
+
+func TestRemoveZeroValues(t *testing.T) {
+	config := struct {
+		MaxEventSize int
+	}{
+		MaxEventSize: 4567,
+	}
+
+	jbytes, err := json.Marshal(config)
+	require.NoError(t, err)
+	configMap := map[string]any{}
+	err = json.Unmarshal(jbytes, &configMap)
+	require.NoError(t, err)
+
+	removeZeroValues(configMap)
+
+	assert.Len(t, configMap, 1)
+	assert.NotZero(t, config.MaxEventSize)
 }

--- a/bootstrap/config/configmock_test.go
+++ b/bootstrap/config/configmock_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 Intel Corporation
+// Copyright (c) 2023 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,127 +20,20 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 )
 
-// WritableInfo is used to hold configuration information that is considered "live" or can be changed on the fly without a restart of the service.
 type WritableInfo struct {
-	// Set level of logging to report
-	//
-	// example: TRACE
-	// required: true
-	// enum: TRACE,DEBUG,INFO,WARN,ERROR
 	LogLevel        string
-	Pipeline        PipelineInfo
 	StoreAndForward StoreAndForwardInfo
-	InsecureSecrets config.InsecureSecrets
 	Telemetry       config.TelemetryInfo
 }
 
-// ConfigurationMockStruct
-// swagger:model ConfigurationMockStruct
 type ConfigurationMockStruct struct {
-	// Writable contains the configuration that change be change on the fly
 	Writable WritableInfo
-	// Registry contains the configuration for connecting the Registry service
 	Registry config.RegistryInfo
-	// Service contains the standard 'service' configuration for the Application service
-	Service config.ServiceInfo
-	// HttpServer contains the configuration for the HTTP Server
-	HttpServer HttpConfig
-	// MessageBus contains the configuration for connecting to the EdgeX MessageBus
-	MessageBus config.MessageBusInfo
-	// Trigger contains the configuration for the Function Pipeline Trigger
-	Trigger TriggerInfo
-	// ApplicationSettings contains the custom configuration for the Application service
-	ApplicationSettings map[string]string
-	// Clients contains the configuration for connecting to the dependent Edgex clients
-	Clients map[string]config.ClientInfo
+	Trigger  TriggerInfo
 }
 
-// TriggerInfo contains Metadata associated with each Trigger
 type TriggerInfo struct {
-	// Type of trigger to start pipeline
-	// enum: http, edgex-messagebus, or external-mqtt
 	Type string
-	// Used when Type=external-mqtt
-	ExternalMqtt ExternalMqttConfig
-}
-
-// HttpConfig contains the addition configuration for HTTP Server
-type HttpConfig struct {
-	// Protocol is the for the HTTP Server to use HTTP or HTTPS
-	// If HTTPS then the Secret store must contain the HTTPS cert and key
-	Protocol string
-	// SecretName is the name in the secret store for the HTTPS cert and key
-	SecretName string
-	// HTTPSCertName is name of the HTTPS cert in the secret store
-	HTTPSCertName string
-	// HTTPSKeyName is name of the HTTPS key in the secret store
-	HTTPSKeyName string
-}
-
-// ExternalMqttConfig contains the MQTT broker configuration for MQTT Trigger
-type ExternalMqttConfig struct {
-	// Url contains the fully qualified URL to connect to the MQTT broker
-	Url string
-	// SubscribeTopics is a comma separated list of topics in which to subscribe
-	SubscribeTopics string
-	// PublishTopic is the topic to publish pipeline output (if any)
-	PublishTopic string
-	// ClientId to connect to the broker with.
-	ClientId string
-	// ConnectTimeout is a time duration indicating how long to wait timing out on the broker connection
-	ConnectTimeout string
-	// AutoReconnect indicated whether or not to retry connection if disconnected
-	AutoReconnect bool
-	// KeepAlive is seconds between client ping when no active data flowing to avoid client being disconnected
-	KeepAlive int64
-	// QoS for MQTT Connection
-	QoS byte
-	// Retain setting for MQTT Connection
-	Retain bool
-	// SkipCertVerify indicates if the certificate verification should be skipped
-	SkipCertVerify bool
-	// SecretPath is the name of the path in secret provider to retrieve your secrets
-	SecretPath string
-	// AuthMode indicates what to use when connecting to the broker. Options are "none", "cacert" , "usernamepassword", "clientcert".
-	// If a CA Cert exists in the SecretPath then it will be used for all modes except "none".
-	AuthMode string
-	// RetryDuration indicates how long (in seconds) to wait timing out on the MQTT client creation
-	RetryDuration int
-	// RetryInterval indicates the time (in seconds) that will be waited between attempts to create MQTT client
-	RetryInterval int
-}
-
-// PipelineInfo defines the top level data for configurable pipelines
-type PipelineInfo struct {
-	// ExecutionOrder is a list of functions, in execution order, for the default configurable pipeline
-	ExecutionOrder string
-	// PerTopicPipelines is a collection of pipelines that only execute if the incoming topic matched the pipelines configured topic
-	PerTopicPipelines map[string]TopicPipeline
-	// UseTargetTypeOfByteArray indicates if raw []byte type is to be used for the TargetType
-	UseTargetTypeOfByteArray bool
-	// TODO: for 3.0 rework this to be a single TargetType with empty, "raw" and "metric" as to allowed values
-	// UseTargetTypeOfMetric indicates the Dtos.Metric is to be used for the TargetType
-	UseTargetTypeOfMetric bool
-	// Functions is a collection of pipeline functions with configured parameters to be used in the ExecutionOrder of one
-	// of the configured pipelines (default or pre topic)
-	Functions map[string]PipelineFunction
-}
-
-// TopicPipeline define the data to a Per Topics functions pipeline
-type TopicPipeline struct {
-	// Id is the unique ID of the pipeline instance
-	Id string
-	// Topics is the set of comma separated topics matched against the incoming to determine if pipeline should execute
-	Topics string
-	// ExecutionOrder is a list of functions, in execution order, for the pipeline instance
-	ExecutionOrder string
-}
-
-// PipelineFunction is a collection of built-in pipeline functions configurations.
-// The map key must be unique start with the name of one of the built-in configurable functions
-type PipelineFunction struct {
-	// Parameters is the collection of configurable parameters specific to the built-in configurable function specified by the map key.
-	Parameters map[string]string
 }
 
 type StoreAndForwardInfo struct {
@@ -149,14 +42,6 @@ type StoreAndForwardInfo struct {
 	MaxRetryCount int
 }
 
-// Credentials encapsulates username-password attributes.
-type Credentials struct {
-	Username string
-	Password string
-}
-
-// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
-// then used to overwrite the service's existing configuration struct.
 func (c *ConfigurationMockStruct) UpdateFromRaw(rawConfig interface{}) bool {
 	configuration, ok := rawConfig.(*ConfigurationMockStruct)
 	if ok {
@@ -165,13 +50,10 @@ func (c *ConfigurationMockStruct) UpdateFromRaw(rawConfig interface{}) bool {
 	return ok
 }
 
-// EmptyWritablePtr returns a pointer to an empty WritableInfo struct.  It is used by the bootstrap to
-// provide the appropriate structure for Config Client's WatchForChanges().
 func (c *ConfigurationMockStruct) EmptyWritablePtr() interface{} {
 	return &WritableInfo{}
 }
 
-// UpdateWritableFromRaw updates the Writeable section of configuration from raw update received from Configuration Provider.
 func (c *ConfigurationMockStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
 	writable, ok := rawWritable.(*WritableInfo)
 	if ok {
@@ -180,37 +62,29 @@ func (c *ConfigurationMockStruct) UpdateWritableFromRaw(rawWritable interface{})
 	return ok
 }
 
-// GetBootstrap returns the configuration elements required by the bootstrap.
 func (c *ConfigurationMockStruct) GetBootstrap() config.BootstrapConfiguration {
 	return config.BootstrapConfiguration{
-		Clients:    c.Clients,
-		Service:    c.transformToBootstrapServiceInfo(),
-		Registry:   c.Registry,
-		MessageBus: c.MessageBus,
+		Service:  c.transformToBootstrapServiceInfo(),
+		Registry: c.Registry,
 	}
 }
 
-// GetLogLevel returns log level from the configuration
 func (c *ConfigurationMockStruct) GetLogLevel() string {
 	return c.Writable.LogLevel
 }
 
-// GetRegistryInfo returns the RegistryInfo section from the configuration
 func (c *ConfigurationMockStruct) GetRegistryInfo() config.RegistryInfo {
 	return c.Registry
 }
 
-// GetInsecureSecrets returns the service's InsecureSecrets.
 func (c *ConfigurationMockStruct) GetInsecureSecrets() config.InsecureSecrets {
-	return c.Writable.InsecureSecrets
+	return config.InsecureSecrets{}
 }
 
-// GetTelemetryInfo returns the service's Telemetry settings.
 func (c *ConfigurationMockStruct) GetTelemetryInfo() *config.TelemetryInfo {
 	return &c.Writable.Telemetry
 }
 
-// transformToBootstrapServiceInfo transforms the SDK's ServiceInfo to the bootstrap's version of ServiceInfo
 func (c *ConfigurationMockStruct) transformToBootstrapServiceInfo() config.ServiceInfo {
-	return c.Service
+	return config.ServiceInfo{}
 }

--- a/bootstrap/config/configmock_test.go
+++ b/bootstrap/config/configmock_test.go
@@ -1,0 +1,216 @@
+//
+// Copyright (c) 2020 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package config
+
+import (
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
+)
+
+// WritableInfo is used to hold configuration information that is considered "live" or can be changed on the fly without a restart of the service.
+type WritableInfo struct {
+	// Set level of logging to report
+	//
+	// example: TRACE
+	// required: true
+	// enum: TRACE,DEBUG,INFO,WARN,ERROR
+	LogLevel        string
+	Pipeline        PipelineInfo
+	StoreAndForward StoreAndForwardInfo
+	InsecureSecrets config.InsecureSecrets
+	Telemetry       config.TelemetryInfo
+}
+
+// ConfigurationMockStruct
+// swagger:model ConfigurationMockStruct
+type ConfigurationMockStruct struct {
+	// Writable contains the configuration that change be change on the fly
+	Writable WritableInfo
+	// Registry contains the configuration for connecting the Registry service
+	Registry config.RegistryInfo
+	// Service contains the standard 'service' configuration for the Application service
+	Service config.ServiceInfo
+	// HttpServer contains the configuration for the HTTP Server
+	HttpServer HttpConfig
+	// MessageBus contains the configuration for connecting to the EdgeX MessageBus
+	MessageBus config.MessageBusInfo
+	// Trigger contains the configuration for the Function Pipeline Trigger
+	Trigger TriggerInfo
+	// ApplicationSettings contains the custom configuration for the Application service
+	ApplicationSettings map[string]string
+	// Clients contains the configuration for connecting to the dependent Edgex clients
+	Clients map[string]config.ClientInfo
+}
+
+// TriggerInfo contains Metadata associated with each Trigger
+type TriggerInfo struct {
+	// Type of trigger to start pipeline
+	// enum: http, edgex-messagebus, or external-mqtt
+	Type string
+	// Used when Type=external-mqtt
+	ExternalMqtt ExternalMqttConfig
+}
+
+// HttpConfig contains the addition configuration for HTTP Server
+type HttpConfig struct {
+	// Protocol is the for the HTTP Server to use HTTP or HTTPS
+	// If HTTPS then the Secret store must contain the HTTPS cert and key
+	Protocol string
+	// SecretName is the name in the secret store for the HTTPS cert and key
+	SecretName string
+	// HTTPSCertName is name of the HTTPS cert in the secret store
+	HTTPSCertName string
+	// HTTPSKeyName is name of the HTTPS key in the secret store
+	HTTPSKeyName string
+}
+
+// ExternalMqttConfig contains the MQTT broker configuration for MQTT Trigger
+type ExternalMqttConfig struct {
+	// Url contains the fully qualified URL to connect to the MQTT broker
+	Url string
+	// SubscribeTopics is a comma separated list of topics in which to subscribe
+	SubscribeTopics string
+	// PublishTopic is the topic to publish pipeline output (if any)
+	PublishTopic string
+	// ClientId to connect to the broker with.
+	ClientId string
+	// ConnectTimeout is a time duration indicating how long to wait timing out on the broker connection
+	ConnectTimeout string
+	// AutoReconnect indicated whether or not to retry connection if disconnected
+	AutoReconnect bool
+	// KeepAlive is seconds between client ping when no active data flowing to avoid client being disconnected
+	KeepAlive int64
+	// QoS for MQTT Connection
+	QoS byte
+	// Retain setting for MQTT Connection
+	Retain bool
+	// SkipCertVerify indicates if the certificate verification should be skipped
+	SkipCertVerify bool
+	// SecretPath is the name of the path in secret provider to retrieve your secrets
+	SecretPath string
+	// AuthMode indicates what to use when connecting to the broker. Options are "none", "cacert" , "usernamepassword", "clientcert".
+	// If a CA Cert exists in the SecretPath then it will be used for all modes except "none".
+	AuthMode string
+	// RetryDuration indicates how long (in seconds) to wait timing out on the MQTT client creation
+	RetryDuration int
+	// RetryInterval indicates the time (in seconds) that will be waited between attempts to create MQTT client
+	RetryInterval int
+}
+
+// PipelineInfo defines the top level data for configurable pipelines
+type PipelineInfo struct {
+	// ExecutionOrder is a list of functions, in execution order, for the default configurable pipeline
+	ExecutionOrder string
+	// PerTopicPipelines is a collection of pipelines that only execute if the incoming topic matched the pipelines configured topic
+	PerTopicPipelines map[string]TopicPipeline
+	// UseTargetTypeOfByteArray indicates if raw []byte type is to be used for the TargetType
+	UseTargetTypeOfByteArray bool
+	// TODO: for 3.0 rework this to be a single TargetType with empty, "raw" and "metric" as to allowed values
+	// UseTargetTypeOfMetric indicates the Dtos.Metric is to be used for the TargetType
+	UseTargetTypeOfMetric bool
+	// Functions is a collection of pipeline functions with configured parameters to be used in the ExecutionOrder of one
+	// of the configured pipelines (default or pre topic)
+	Functions map[string]PipelineFunction
+}
+
+// TopicPipeline define the data to a Per Topics functions pipeline
+type TopicPipeline struct {
+	// Id is the unique ID of the pipeline instance
+	Id string
+	// Topics is the set of comma separated topics matched against the incoming to determine if pipeline should execute
+	Topics string
+	// ExecutionOrder is a list of functions, in execution order, for the pipeline instance
+	ExecutionOrder string
+}
+
+// PipelineFunction is a collection of built-in pipeline functions configurations.
+// The map key must be unique start with the name of one of the built-in configurable functions
+type PipelineFunction struct {
+	// Parameters is the collection of configurable parameters specific to the built-in configurable function specified by the map key.
+	Parameters map[string]string
+}
+
+type StoreAndForwardInfo struct {
+	Enabled       bool
+	RetryInterval string
+	MaxRetryCount int
+}
+
+// Credentials encapsulates username-password attributes.
+type Credentials struct {
+	Username string
+	Password string
+}
+
+// UpdateFromRaw converts configuration received from the registry to a service-specific configuration struct which is
+// then used to overwrite the service's existing configuration struct.
+func (c *ConfigurationMockStruct) UpdateFromRaw(rawConfig interface{}) bool {
+	configuration, ok := rawConfig.(*ConfigurationMockStruct)
+	if ok {
+		*c = *configuration
+	}
+	return ok
+}
+
+// EmptyWritablePtr returns a pointer to an empty WritableInfo struct.  It is used by the bootstrap to
+// provide the appropriate structure for Config Client's WatchForChanges().
+func (c *ConfigurationMockStruct) EmptyWritablePtr() interface{} {
+	return &WritableInfo{}
+}
+
+// UpdateWritableFromRaw updates the Writeable section of configuration from raw update received from Configuration Provider.
+func (c *ConfigurationMockStruct) UpdateWritableFromRaw(rawWritable interface{}) bool {
+	writable, ok := rawWritable.(*WritableInfo)
+	if ok {
+		c.Writable = *writable
+	}
+	return ok
+}
+
+// GetBootstrap returns the configuration elements required by the bootstrap.
+func (c *ConfigurationMockStruct) GetBootstrap() config.BootstrapConfiguration {
+	return config.BootstrapConfiguration{
+		Clients:    c.Clients,
+		Service:    c.transformToBootstrapServiceInfo(),
+		Registry:   c.Registry,
+		MessageBus: c.MessageBus,
+	}
+}
+
+// GetLogLevel returns log level from the configuration
+func (c *ConfigurationMockStruct) GetLogLevel() string {
+	return c.Writable.LogLevel
+}
+
+// GetRegistryInfo returns the RegistryInfo section from the configuration
+func (c *ConfigurationMockStruct) GetRegistryInfo() config.RegistryInfo {
+	return c.Registry
+}
+
+// GetInsecureSecrets returns the service's InsecureSecrets.
+func (c *ConfigurationMockStruct) GetInsecureSecrets() config.InsecureSecrets {
+	return c.Writable.InsecureSecrets
+}
+
+// GetTelemetryInfo returns the service's Telemetry settings.
+func (c *ConfigurationMockStruct) GetTelemetryInfo() *config.TelemetryInfo {
+	return &c.Writable.Telemetry
+}
+
+// transformToBootstrapServiceInfo transforms the SDK's ServiceInfo to the bootstrap's version of ServiceInfo
+func (c *ConfigurationMockStruct) transformToBootstrapServiceInfo() config.ServiceInfo {
+	return c.Service
+}

--- a/config/types.go
+++ b/config/types.go
@@ -31,6 +31,16 @@ const (
 	MessageBusSubscribeTopic     = "SubscribeTopic"
 )
 
+const (
+	ServiceTypeApp    = "app-service"
+	ServiceTypeDevice = "device-service"
+	ServiceTypeOther  = "other"
+)
+
+const (
+	CommonConfigDone = "IsCommonConfigReady"
+)
+
 // ServiceInfo contains configuration settings necessary for the basic operation of any EdgeX service.
 type ServiceInfo struct {
 	// HealthCheckInterval is the interval for Registry heal check callback

--- a/config/types.go
+++ b/config/types.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2018 Dell Inc.
- * Copyright 2022 Intel Inc.
+ * Copyright 2023 Intel Corporation
  * Copyright 2021-2022 IOTech Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -35,6 +35,7 @@ const (
 	ServiceTypeApp    = "app-service"
 	ServiceTypeDevice = "device-service"
 	ServiceTypeOther  = "other"
+	//TOOD: add security-service to use in place of useSecretProvider
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/consulstructure v0.0.0-20190329231841-56fdc4d2da54 // indirect
-	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/mitchellh/copystructure v1.0.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/stretchr/testify v1.8.1


### PR DESCRIPTION
BREAKING CHANGE: calls to bootstrap.RunAndReturnWaitGroup must include the service type

Signed-off-by: Elizabeth J Lee <elizabeth.j.lee@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - common config docs will need to be added
  <link to docs PR>

## Testing Instructions

**Non-secure mode testing**
1. set the environment variable for non-secure testing `export EDGEX_SECURITY_SECRET_STORE=false`
2. run the latest compose builder `make run no-secty` to start core services
3. stop core data
4. remove the core data configuration in consul
5. modify local go-mod in edgex-go to use local bootstrap using `replace` statement
6. modify the configuration.toml for core-data to remove anything in configuration.yaml from common config.
7. build common config and core data `make data`
9. run core-data locally and ensure that the configuration loads `cd cmd/core-data` and `./core-data -cp=consul.http://localhost:8500`
10. Verify that the core data configuration was loaded into consul

**Secure mode testing**
1. set the environment variable for secure testing `export EDGEX_SECURITY_SECRET_STORE=true`
2. run the latest compose builder `make run` to start core services
3. stop core data
4. remove the core data configuration in consul
5. modify local go-mod in edgex-go to use local bootstrap using `replace` statement
6. modify the configuration.toml for core-data to remove anything in configuration.yaml from common config.
7. build common config and core data `make data`
9. run core-data locally and ensure that the configuration loads `cd cmd/core-data` and `sudo ./core-data -cp=consul.http://localhost:8500`
10. Verify that the core data configuration was loaded into consul

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->