### PR TITLE
fix: move listen for changes for private config to run on startup

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -183,7 +183,6 @@ func (cp *Processor) Process(
 			}
 
 			cp.lc.Info("Configuration has been pushed to into Configuration Provider")
-			cp.listenForChanges(serviceConfig, privateConfigClient)
 		}
 
 	}
@@ -193,8 +192,13 @@ func (cp *Processor) Process(
 	if err != nil {
 		return err
 	}
-
 	cp.lc.Infof("Configuration loaded with %d overrides applied", overrideCount)
+
+	// listen for changes on Writable
+	if useProvider {
+		cp.listenForChanges(serviceConfig, privateConfigClient)
+		cp.lc.Infof("listening for private config changes")
+	}
 
 	// Now that configuration has been loaded and overrides applied the log level can be set as configured.
 	err = cp.lc.SetLogLevel(serviceConfig.GetLogLevel())


### PR DESCRIPTION
Signed-off-by: Elizabeth J Lee <elizabeth.j.lee@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) - bootstrap change for private config
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - common config feature needs documentation
  <link to docs PR>

## Testing Instructions
1. start compose stack in non-secure mode
2. point device-sdk device simple to the local bootstrap
3. build device simple and run with config provider
4. change the writable loglevel and ensure the log level changes

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->