### PR TITLE
fix: retry logic for checking if common config is ready

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -677,7 +677,7 @@ func (cp *Processor) waitForCommonConfig(configClient configuration.Client) erro
 		isCommonConfigReady, err = strconv.ParseBool(string(commonConfigReady))
 		if err != nil {
 			cp.lc.Warnf("did not get boolean from config provider for %s: %s", config.CommonConfigDone, err.Error())
-			isConfigReady = false
+			isCommonConfigReady = false
 		}
 		if isCommonConfigReady {
 			isConfigReady = true

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -676,7 +676,8 @@ func (cp *Processor) waitForCommonConfig(configClient configuration.Client) erro
 
 		isCommonConfigReady, err = strconv.ParseBool(string(commonConfigReady))
 		if err != nil {
-			return fmt.Errorf("did not get boolean from config provider for %s: %s", config.CommonConfigDone, err.Error())
+			cp.lc.Warnf("did not get boolean from config provider for %s: %s", config.CommonConfigDone, err.Error())
+			isConfigReady = false
 		}
 		if isCommonConfigReady {
 			isConfigReady = true
@@ -694,7 +695,7 @@ func (cp *Processor) waitForCommonConfig(configClient configuration.Client) erro
 		}
 	}
 	if !isConfigReady {
-		return errors.New("common config is not loaded")
+		return errors.New("common config is not loaded - did core-common-config-bootstrapper run?")
 	}
 	return nil
 }

--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -150,7 +150,6 @@ func TestLoadCommonConfig(t *testing.T) {
 	testErr := errors.New("test error")
 	configProviderErr := "configuration provider is not available"
 	loadErr := "common config is not loaded"
-	noBoolErr := "did not get boolean from config provider for IsCommonConfigReady"
 	getConfigErr := fmt.Sprintf("failed to load the common configuration for %s: %s", allServicesKey, testErr.Error())
 
 	tests := []struct {
@@ -176,7 +175,7 @@ func TestLoadCommonConfig(t *testing.T) {
 		{"Invalid - common config not ready", &serviceConfig, config.ServiceTypeOther, nil,
 			nil, true, []byte("false"), nil, nil, loadErr},
 		{"Invalid - common config ready parameter invalid", &serviceConfig, config.ServiceTypeOther, nil,
-			nil, true, []byte("bogus"), nil, nil, noBoolErr},
+			nil, true, []byte("bogus"), nil, nil, loadErr},
 		{"Invalid - common config not ready error", &serviceConfig, config.ServiceTypeOther, nil,
 			nil, true, []byte("false"), testErr, nil, loadErr},
 		{"Valid - core service", &serviceConfig, config.ServiceTypeOther, nil,


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) - docs need to be added for common config
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. run edgex stack in non-secure mode
2. stop core data and remove core-data from config provider
3. modify edgex-go/go.mod to use local bootstrap
4. run core-data with config provider
5. verify core data is in the config provider


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->