### PR TITLE
fix: Authentication status is now DEBUG, auth failure is WARN

### DIFF
--- a/bootstrap/handlers/auth_middleware.go
+++ b/bootstrap/handlers/auth_middleware.go
@@ -47,7 +47,7 @@ func VaultAuthenticationHandlerFunc(secretProvider interfaces.SecretProvider, lc
 	return func(inner http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
-			lc.Infof("Authorizing incoming call to '%s' via JWT (Authorization len=%d)", r.URL.Path, len(authHeader))
+			lc.Debugf("Authorizing incoming call to '%s' via JWT (Authorization len=%d)", r.URL.Path, len(authHeader))
 			authParts := strings.Split(authHeader, " ")
 			if len(authParts) >= 2 && strings.EqualFold(authParts[0], "Bearer") {
 				token := authParts[1]
@@ -57,11 +57,11 @@ func VaultAuthenticationHandlerFunc(secretProvider interfaces.SecretProvider, lc
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 					return
 				} else if !validToken {
-					lc.Infof("Request to '%s' UNAUTHORIZED", r.URL.Path)
+					lc.Warnf("Request to '%s' UNAUTHORIZED", r.URL.Path)
 					http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 					return
 				}
-				lc.Infof("Request to '%s' authorized", r.URL.Path)
+				lc.Debug("Request to '%s' authorized", r.URL.Path)
 				inner(w, r)
 				return
 			}


### PR DESCRIPTION
Authentication tracing was very chatty, which was useful during development.
Now that the feature is merged, authentication attempts are now logged at DEBUG level,
as well as authorization success.  Authorization failures are now logged as WARNING.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
`make test` to ensure no breakage.
otherwise no major functional impact of these changes.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->