### PR TITLE
feat!: Apply env overrides only when config loaded from file

### DIFF
--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -204,7 +204,7 @@ func (e *Variables) buildOverrideNames(paths []string) map[string]string {
 func (_ *Variables) getOverrideNameFor(path string) string {
 	// ".", "/" & "-" are the only special character allowed in path not allowed in environment variable Name
 	override := strings.ReplaceAll(path, tomlPathDotSeparator, envNameSeparator)
-	override = strings.ReplaceAll(path, tomlPathSlashSeparator, envNameSeparator)
+	override = strings.ReplaceAll(override, tomlPathSlashSeparator, envNameSeparator)
 	override = strings.ReplaceAll(override, tomlNameSeparator, envNameSeparator)
 	override = strings.ToUpper(override)
 	return override


### PR DESCRIPTION
BREAKING CHANGE: Overrides are no longer applied to values pulled from Configuration Provider. Configuration Provideris now the system or record for configuration, when used.

closes #482

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **Existing tests suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Run non-secure EdgeX stack
Stop Core Data container.
Remove Core Data config from Consul
Build Core Data using go-mod-bootstrap from this branch
run `export WRITABLE_LOGLEVEL=DEBUG`
Run core data from command-line with `-cp`
Verify logs contain the following:
```
"Using Configuration provider (consul) from: http://localhost:8500 with base path of edgex/v3/core-common-config-bootstrapper/all-services"
"Common configuration loaded from the Configuration Provider. No overrides applied"
"Using Configuration provider (consul) from: http://localhost:8500 with base path of edgex/v3/core-data"
"Loaded private configuration from ./res/configuration.toml"
"Variables override of 'Writable.LogLevel' by environment variable: WRITABLE_LOGLEVEL=DEBUG"
"Configuration loaded from file with 1 overrides applied"
"Configuration has been pushed to into Configuration Provider with overrides applied"
```
Verify `edgex/v3/core-data/Writable/LogLevel` is set to DEBUG
Change it to `INFO`
Stop and re-run Core Data
Verify logs contain the following:
```
"Using Configuration provider (consul) from: http://localhost:8500 with base path of edgex/v3/core-common-config-bootstrapper/all-services"
"Common configuration loaded from the Configuration Provider. No overrides applied"
"Using Configuration provider (consul) from: http://localhost:8500 with base path of edgex/v3/core-data"
"Private configuration loaded from the Configuration Provider. No overrides applied"
```
Verify Verify `edgex/v3/core-data/Writable/LogLevel` is still set to INFO

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->