### PR TITLE
refactor!: Switch to loading configuation files as YAML

### DIFF
--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	DefaultConfigProvider = "consul.http://localhost:8500"
-	DefaultConfigFile     = "configuration.toml"
+	DefaultConfigFile     = "configuration.yaml"
 )
 
 // Common is an interface that defines AP for the common command-line flags used by most EdgeX services


### PR DESCRIPTION
BREAKING CHANGE: All configruation file must now be in YAML format. The default file name has changed to be configuration.yaml

closes #424

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **existing suffice**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
run non-secure EdgeX stack
Stope core data and remove core data config from Consul
Build core data with this branch
Convert core data config to YAML
Run core data from command line with just -cp
Verify core data config loaded and pushed to consul 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->