### PR TITLE
feat: Add command line/environment flag for commonConfig

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -339,9 +339,9 @@ func (cp *Processor) loadCommonConfigFromFile(
 		return err
 	}
 	// separate out the necessary sections
-	allServicesConfig, ok := commonConfig["all-services"].(map[string]any)
+	allServicesConfig, ok := commonConfig[allServicesKey].(map[string]any)
 	if !ok {
-		return fmt.Errorf("could not find all-services section in common config %s", configFile)
+		return fmt.Errorf("could not find %s section in common config %s", allServicesKey, configFile)
 	}
 	// use the service type to separate out the necessary sections
 	var serviceTypeConfig map[string]any
@@ -595,14 +595,14 @@ func (cp *Processor) loadPrivateFromFile() (*toml.Tree, error) {
 }
 
 // loadConfigYamlFromFile attempts to read the configuration yaml file
-func (cp *Processor) loadConfigYamlFromFile(yamlFile string) (map[string]interface{}, error) {
+func (cp *Processor) loadConfigYamlFromFile(yamlFile string) (map[string]any, error) {
 	cp.lc.Infof("reading %s", yamlFile)
 	contents, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read common configuration file %s: %s", yamlFile, err.Error())
 	}
 
-	data := make(map[string]interface{})
+	data := make(map[string]any)
 
 	err = yaml.Unmarshal(contents, &data)
 	if err != nil {

--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -247,7 +247,7 @@ func TestLoadCommonConfig(t *testing.T) {
 	}
 }
 
-func TestLoadCommonConfigFromUri(t *testing.T) {
+func TestLoadCommonConfigFromFile(t *testing.T) {
 	tests := []struct {
 		Name          string
 		config        string
@@ -259,9 +259,9 @@ func TestLoadCommonConfigFromUri(t *testing.T) {
 		{"Valid - app service", path.Join(".", "testdata", "configuration.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeApp, ""},
 		{"Valid - device service", path.Join(".", "testdata", "configuration.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeDevice, ""},
 		{"Invalid - bad config file", path.Join(".", "testdata", "bad_config.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeOther, "no such file or directory"},
-		{"Invalid - missing all service", path.Join(".", "testdata", "bogus.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeOther, "could not find all-services section in config"},
-		{"Invalid - missing app service", path.Join(".", "testdata", "all-service-config.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeApp, fmt.Sprintf("could not find %s section in config", appServicesKey)},
-		{"Invalid - missing device service", path.Join(".", "testdata", "all-service-config.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeDevice, fmt.Sprintf("could not find %s section in config", deviceServicesKey)},
+		{"Invalid - missing all service", path.Join(".", "testdata", "bogus.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeOther, "could not find all-services section in common config"},
+		{"Invalid - missing app service", path.Join(".", "testdata", "all-service-config.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeApp, fmt.Sprintf("could not find %s section in common config", appServicesKey)},
+		{"Invalid - missing device service", path.Join(".", "testdata", "all-service-config.yaml"), &ConfigurationMockStruct{}, config.ServiceTypeDevice, fmt.Sprintf("could not find %s section in common config", deviceServicesKey)},
 	}
 
 	for _, tc := range tests {
@@ -282,12 +282,12 @@ func TestLoadCommonConfigFromUri(t *testing.T) {
 			proc := NewProcessor(f, env, timer, ctx, &wg, nil, dic)
 
 			// call load common config
-			err := proc.loadCommonConfigFromUri(tc.config, tc.serviceConfig, tc.serviceType)
+			err := proc.loadCommonConfigFromFile(tc.config, tc.serviceConfig, tc.serviceType)
 			// make assertions
 			require.NotNil(t, cancel)
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)
-				assert.NotEmpty(t, tc.serviceType)
+				assert.NotEmpty(t, tc.serviceConfig)
 				return
 			}
 			assert.Contains(t, err.Error(), tc.expectedErr)

--- a/bootstrap/config/testdata/all-service-config.yaml
+++ b/bootstrap/config/testdata/all-service-config.yaml
@@ -1,0 +1,76 @@
+all-services:
+  Writable:
+    InsecureSecrets:
+      DB:
+        path: "redisdb"
+        Secrets:
+          username: ""
+          password: ""
+        SecretName: "redisdb"
+        SecretData:
+          username: ""
+          password: ""
+    
+    Telemetry:
+      Interval: "30s"
+      Metrics:
+        # Common Security Service Metrics
+        SecuritySecretsRequested: false
+        SecuritySecretsStored: false
+        SecurityConsulTokensRequested: false
+        SecurityConsulTokenDuration: false
+      Tags: # Contains the service level tags to be attached to all the service's metrics
+      #  Gateway: "my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
+      
+  Service:
+    HealthCheckInterval: "10s"
+    Host: "localhost"
+    ServerBindAddr: "" # Leave blank so default to Host value unless different value is needed.
+    MaxResultCount: 1024
+    MaxRequestSize: 0 # Not currently used. Defines the maximum size of http request body in bytes
+    RequestTimeout: "5s"
+    CORSConfiguration:
+      EnableCORS: false
+      CORSAllowCredentials: false
+      CORSAllowedOrigin: "https://localhost"
+      CORSAllowedMethods: "GET, POST, PUT, PATCH, DELETE"
+      CORSAllowedHeaders: "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+      CORSExposeHeaders: "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+      CORSMaxAge: 3600
+
+  Registry:
+    Host: "localhost"
+    Port: 8500
+    Type: "consul"
+  
+  Database:
+    Host: "localhost"
+    Port: 6379
+    Timeout: 5000
+    Type: "redisdb"
+  
+  MessageBus:
+    Protocol: "redis"
+    Host: "localhost"
+    Port: 6379
+    Type: "redis"
+    AuthMode: "usernamepassword"  # required for redis MessageBus (secure or insecure).
+    SecretName: "redisdb"
+    BaseTopicPrefix: "edgex" # prepended to all topics as "edgex/<additional topic levels>
+    Optional:
+      # Default MQTT Specific options that need to be here to enable environment variable overrides of them
+      Qos:  "0" # Quality of Service values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+      KeepAlive: "10" # Seconds (must be 2 or greater)
+      Retained: "false"
+      AutoReconnect: "true"
+      ConnectTimeout: "5" # Seconds
+      SkipCertVerify: "false"
+      # Additional Default NATS Specific options that need to be here to enable environment variable overrides of them
+      Format: "nats"
+      RetryOnFailedConnect: "true"
+      QueueGroup: ""
+      Durable: ""
+      AutoProvision: "true"
+      Deliver: "new"
+      DefaultPubRetryAttempts: "2"
+      Subject: "edgex/#" # Required for NATS JetStream only for stream auto-provisioning

--- a/bootstrap/config/testdata/configuration.yaml
+++ b/bootstrap/config/testdata/configuration.yaml
@@ -1,0 +1,129 @@
+all-services:
+  Writable:
+    InsecureSecrets:
+      DB:
+        path: "redisdb"
+        Secrets:
+          username: ""
+          password: ""
+        SecretName: "redisdb"
+        SecretData:
+          username: ""
+          password: ""
+    
+    Telemetry:
+      Interval: "30s"
+      Metrics:
+        # Common Security Service Metrics
+        SecuritySecretsRequested: false
+        SecuritySecretsStored: false
+        SecurityConsulTokensRequested: false
+        SecurityConsulTokenDuration: false
+#     Tags: # Contains the service level tags to be attached to all the service's metrics
+      #  Gateway: "my-iot-gateway" # Tag must be added here or via Consul Env Override can only change existing value, not added new ones.
+      
+  Service:
+    HealthCheckInterval: "10s"
+    Host: "localhost"
+    ServerBindAddr: "" # Leave blank so default to Host value unless different value is needed.
+    MaxResultCount: 1024
+    MaxRequestSize: 0 # Not currently used. Defines the maximum size of http request body in bytes
+    RequestTimeout: "5s"
+    CORSConfiguration:
+      EnableCORS: false
+      CORSAllowCredentials: false
+      CORSAllowedOrigin: "https://localhost"
+      CORSAllowedMethods: "GET, POST, PUT, PATCH, DELETE"
+      CORSAllowedHeaders: "Authorization, Accept, Accept-Language, Content-Language, Content-Type, X-Correlation-ID"
+      CORSExposeHeaders: "Cache-Control, Content-Language, Content-Length, Content-Type, Expires, Last-Modified, Pragma, X-Correlation-ID"
+      CORSMaxAge: 3600
+
+  Registry:
+    Host: "localhost"
+    Port: 8500
+    Type: "consul"
+  
+  Database:
+    Host: "localhost"
+    Port: 6379
+    Timeout: 5000
+    Type: "redisdb"
+  
+  MessageBus:
+    Protocol: "redis"
+    Host: "localhost"
+    Port: 6379
+    Type: "redis"
+    AuthMode: "usernamepassword"  # required for redis MessageBus (secure or insecure).
+    SecretName: "redisdb"
+    BaseTopicPrefix: "edgex" # prepended to all topics as "edgex/<additional topic levels>
+    Optional:
+      # Default MQTT Specific options that need to be here to enable environment variable overrides of them
+      Qos:  "0" # Quality of Service values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+      KeepAlive: "10" # Seconds (must be 2 or greater)
+      Retained: "false"
+      AutoReconnect: "true"
+      ConnectTimeout: "5" # Seconds
+      SkipCertVerify: "false"
+      # Additional Default NATS Specific options that need to be here to enable environment variable overrides of them
+      Format: "nats"
+      RetryOnFailedConnect: "true"
+      QueueGroup: ""
+      Durable: ""
+      AutoProvision: "true"
+      Deliver: "new"
+      DefaultPubRetryAttempts: "2"
+      Subject: "edgex/#" # Required for NATS JetStream only for stream auto-provisioning
+
+app-services:
+  Writable:
+    StoreAndForward:
+      Enabled: false
+      RetryInterval: "5m"
+      MaxRetryCount: 10
+    Telemetry:
+      Metrics:
+        MessagesReceived: false
+        InvalidMessagesReceived: false
+        PipelineMessagesProcessed: false # Pipeline IDs are added as the tag for the metric for each pipeline defined
+        PipelineMessageProcessingTime: false # Pipeline IDs are added as the tag for the metric for each pipeline defined
+        PipelineProcessingErrors: false # Pipeline IDs are added as the tag for the metric for each pipeline defined
+        HttpExportSize: false # Single metric used for all HTTP Exports
+        MqttExportSize: false # BrokerAddress and Topic are added as the tag for this metric for each MqttExport defined
+  Clients:
+    core-metadata:
+      Protocol: "http"
+      Host: "localhost"
+      Port: 59881
+  Trigger:
+    Type: "edgex-messagebus"
+    SubscribeTopics: "events/#" # Base topic is prepended to this topic when using edgex-messagebus
+
+device-services:
+  MaxEventSize: 0 # value 0 represents unlimited  maximum event size that can be sent to message bus or core-data
+  Writable:
+    Reading:
+      ReadingUnits: true
+    Telemetry:
+      Metrics:
+        EventsSent: false
+        ReadingsSent: false
+  Clients:
+    core-metadata:
+      Protocol: "http"
+      Host: "localhost"
+      Port: 59881
+  Device:
+    DataTransform: true
+    MaxCmdOps: 128
+    MaxCmdValueLen: 256
+    ProfilesDir: "./res/profiles"
+    DevicesDir: "./res/devices"
+    # ProvisionWatchersDir is omitted here since most Device Services don't use it.
+    # Those that do will have it in their private config
+    EnableAsyncReadings: true
+    AsyncBufferSize: 16
+    Labels: []
+    Discovery:
+      Enabled: false
+      Interval: "30s"

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -368,16 +368,16 @@ func GetConfigFileName(lc logger.LoggingClient, configFileName string) string {
 	return configFileName
 }
 
-// GetCommonConfig gets the common configuration value from the Variables value (if it exists)
+// GetCommonConfigFileName gets the common configuration value from the Variables value (if it exists)
 // or uses passed in value.
-func GetCommonConfig(lc logger.LoggingClient, commonConfig string) string {
+func GetCommonConfigFileName(lc logger.LoggingClient, commonConfigFileName string) string {
 	envValue := os.Getenv(envKeyCommonConfig)
 	if len(envValue) > 0 {
-		commonConfig = envValue
+		commonConfigFileName = envValue
 		logEnvironmentOverride(lc, "-cc/--commonConfig", envKeyCommonConfig, envValue)
 	}
 
-	return commonConfig
+	return commonConfigFileName
 }
 
 // parseCommaSeparatedSlice converts comma separated list to a string slice

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -37,12 +37,13 @@ const (
 	defaultConfigDirValue     = "./res"
 
 	envKeyConfigUrl       = "EDGEX_CONFIG_PROVIDER"
+	envKeyCommonConfig    = "EDGEX_COMMON_CONFIG"
 	envKeyUseRegistry     = "EDGEX_USE_REGISTRY"
 	envKeyStartupDuration = "EDGEX_STARTUP_DURATION"
 	envKeyStartupInterval = "EDGEX_STARTUP_INTERVAL"
-	envConfigDir          = "EDGEX_CONFIG_DIR"
-	envProfile            = "EDGEX_PROFILE"
-	envConfigFile         = "EDGEX_CONFIG_FILE"
+	envKeyConfigDir       = "EDGEX_CONFIG_DIR"
+	envKeyProfile         = "EDGEX_PROFILE"
+	envKeyConfigFile      = "EDGEX_CONFIG_FILE"
 
 	noConfigProviderValue = "none"
 
@@ -326,10 +327,10 @@ func GetStartupInfo(serviceKey string) StartupInfo {
 // GetConfigDir get the config directory value from a Variables variable value (if it exists)
 // or uses passed in value or default if previous result in blank.
 func GetConfigDir(lc logger.LoggingClient, configDir string) string {
-	envValue := os.Getenv(envConfigDir)
+	envValue := os.Getenv(envKeyConfigDir)
 	if len(envValue) > 0 {
 		configDir = envValue
-		logEnvironmentOverride(lc, "-cd/-configDir", envConfigDir, envValue)
+		logEnvironmentOverride(lc, "-cd/-configDir", envKeyConfigDir, envValue)
 	}
 
 	if len(configDir) == 0 {
@@ -342,10 +343,10 @@ func GetConfigDir(lc logger.LoggingClient, configDir string) string {
 // GetProfileDir get the profile directory value from a Variables variable value (if it exists)
 // or uses passed in value or default if previous result in blank.
 func GetProfileDir(lc logger.LoggingClient, profileDir string) string {
-	envValue := os.Getenv(envProfile)
+	envValue := os.Getenv(envKeyProfile)
 	if len(envValue) > 0 {
 		profileDir = envValue
-		logEnvironmentOverride(lc, "-p/-profile", envProfile, envValue)
+		logEnvironmentOverride(lc, "-p/-profile", envKeyProfile, envValue)
 	}
 
 	if len(profileDir) > 0 {
@@ -358,13 +359,25 @@ func GetProfileDir(lc logger.LoggingClient, profileDir string) string {
 // GetConfigFileName gets the configuration filename value from a Variables variable value (if it exists)
 // or uses passed in value.
 func GetConfigFileName(lc logger.LoggingClient, configFileName string) string {
-	envValue := os.Getenv(envConfigFile)
+	envValue := os.Getenv(envKeyConfigFile)
 	if len(envValue) > 0 {
 		configFileName = envValue
-		logEnvironmentOverride(lc, "-cf/--configFile", envConfigFile, envValue)
+		logEnvironmentOverride(lc, "-cf/--configFile", envKeyConfigFile, envValue)
 	}
 
 	return configFileName
+}
+
+// GetCommonConfig gets the common configuration value from the Variables value (if it exists)
+// or uses passed in value.
+func GetCommonConfig(lc logger.LoggingClient, commonConfig string) string {
+	envValue := os.Getenv(envKeyCommonConfig)
+	if len(envValue) > 0 {
+		commonConfig = envValue
+		logEnvironmentOverride(lc, "-cc/--commonConfig", envKeyCommonConfig, envValue)
+	}
+
+	return commonConfig
 }
 
 // parseCommaSeparatedSlice converts comma separated list to a string slice

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -159,7 +159,7 @@ func TestGetConfigDir(t *testing.T) {
 		PassedInName string
 		ExpectedName string
 	}{
-		{"With Env Var", envConfigDir, "res", "myres"},
+		{"With Env Var", envKeyConfigDir, "res", "myres"},
 		{"With No Env Var", "", "res", "res"},
 		{"With No Env Var and no passed in", "", "", defaultConfigDirValue},
 	}
@@ -189,7 +189,7 @@ func TestGetProfileDir(t *testing.T) {
 		PassedInName string
 		ExpectedName string
 	}{
-		{"With V2 Env Var", envProfile, "myProfileV2", "sample", "myProfileV2/"},
+		{"With V2 Env Var", envKeyProfile, "myProfileV2", "sample", "myProfileV2/"},
 		{"With No Env Var", "", "", "sample", "sample/"},
 		{"With No Env Var and no passed in", "", "", "", ""},
 	}
@@ -218,7 +218,7 @@ func TestGetConfigFileName(t *testing.T) {
 		PassedInName string
 		ExpectedName string
 	}{
-		{"With Env Var", envConfigFile, "configuration.toml", "config.toml"},
+		{"With Env Var", envKeyConfigFile, "configuration.toml", "config.toml"},
 		{"With No Env Var", "", "configuration.toml", "configuration.toml"},
 		{"With No Env Var and no passed in", "", "", ""},
 	}
@@ -233,6 +233,35 @@ func TestGetConfigFileName(t *testing.T) {
 			}
 
 			actual := GetConfigFileName(lc, test.PassedInName)
+			assert.Equal(t, test.ExpectedName, actual)
+		})
+	}
+}
+
+func TestGetCommonConfig(t *testing.T) {
+	_, lc := initializeTest()
+
+	testCases := []struct {
+		TestName     string
+		EnvName      string
+		PassedInName string
+		ExpectedName string
+	}{
+		{"With Env Var", envKeyCommonConfig, "configuration.yaml", "config.yaml"},
+		{"With No Env Var", "", "configuration.yaml", "configuration.yaml"},
+		{"With No Env Var and no passed in", "", "", ""},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.TestName, func(t *testing.T) {
+			os.Clearenv()
+
+			if len(test.EnvName) > 0 {
+				err := os.Setenv(test.EnvName, test.ExpectedName)
+				require.NoError(t, err)
+			}
+
+			actual := GetCommonConfig(lc, test.PassedInName)
 			assert.Equal(t, test.ExpectedName, actual)
 		})
 	}

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -238,7 +238,7 @@ func TestGetConfigFileName(t *testing.T) {
 	}
 }
 
-func TestGetCommonConfig(t *testing.T) {
+func TestGetCommonConfigFileName(t *testing.T) {
 	_, lc := initializeTest()
 
 	testCases := []struct {
@@ -261,7 +261,7 @@ func TestGetCommonConfig(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			actual := GetCommonConfig(lc, test.PassedInName)
+			actual := GetCommonConfigFileName(lc, test.PassedInName)
 			assert.Equal(t, test.ExpectedName, actual)
 		})
 	}

--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -154,7 +154,7 @@ func (d *Default) helpCallback() {
 			"Server Options:\n"+
 			"    -cp, --configProvider           Indicates to use Configuration Provider service at specified URL.\n"+
 			"                                    URL Format: {type}.{protocol}://{host}:{port} ex: consul.http://localhost:8500\n"+
-			"    -cc, --commonConfig             Takes the location to specifies where the common configuration is loaded from when\n"+
+			"    -cc, --commonConfig             Takes the location where the common configuration is loaded from when\n"+
 			"                                    not using the Configuration Provider\n"+
 			"    -o, --overwrite                 Overwrite configuration in provider with local configuration\n"+
 			"                                    *** Use with cation *** Use will clobber existing settings in provider,\n"+

--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -34,6 +34,7 @@ type Common interface {
 	Profile() string
 	ConfigDirectory() string
 	ConfigFileName() string
+	CommonConfig() string
 	Parse([]string)
 	Help()
 }
@@ -45,6 +46,7 @@ type Default struct {
 	overwriteConfig   bool
 	useRegistry       bool
 	configProviderUrl string
+	commonConfig      string
 	profile           string
 	configDir         string
 	configFileName    string
@@ -80,9 +82,11 @@ func (d *Default) Parse(arguments []string) {
 		}
 	}
 
-	// Usage is provided by caller, so leaving individual usage blank here so not confusing where if comes from.
+	// Usage is provided by caller, so leaving individual usage blank here so not confusing where it comes from.
 	d.FlagSet.StringVar(&d.configProviderUrl, "configProvider", "", "")
 	d.FlagSet.StringVar(&d.configProviderUrl, "cp", "", "")
+	d.FlagSet.StringVar(&d.commonConfig, "commonConfig", "", "")
+	d.FlagSet.StringVar(&d.commonConfig, "cc", "", "")
 	d.FlagSet.BoolVar(&d.overwriteConfig, "overwrite", false, "")
 	d.FlagSet.BoolVar(&d.overwriteConfig, "o", false, "")
 	d.FlagSet.StringVar(&d.configFileName, "cf", DefaultConfigFile, "")
@@ -133,6 +137,11 @@ func (d *Default) ConfigFileName() string {
 	return d.configFileName
 }
 
+// CommonConfig returns the uri for the common configuration
+func (d *Default) CommonConfig() string {
+	return d.commonConfig
+}
+
 // Help displays the usage help message and exit.
 func (d *Default) Help() {
 	d.helpCallback()
@@ -145,6 +154,8 @@ func (d *Default) helpCallback() {
 			"Server Options:\n"+
 			"    -cp, --configProvider           Indicates to use Configuration Provider service at specified URL.\n"+
 			"                                    URL Format: {type}.{protocol}://{host}:{port} ex: consul.http://localhost:8500\n"+
+			"    -cc, --commonConfig             Takes the URI that specifies where the common configuration is pulled from when\n"+
+			"                                    not using the Configuration Provider\n"+
 			"    -o, --overwrite                 Overwrite configuration in provider with local configuration\n"+
 			"                                    *** Use with cation *** Use will clobber existing settings in provider,\n"+
 			"                                    problematic if those settings were edited by hand intentionally\n"+

--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -137,7 +137,7 @@ func (d *Default) ConfigFileName() string {
 	return d.configFileName
 }
 
-// CommonConfig returns the uri for the common configuration
+// CommonConfig returns the location for the common configuration
 func (d *Default) CommonConfig() string {
 	return d.commonConfig
 }
@@ -154,7 +154,7 @@ func (d *Default) helpCallback() {
 			"Server Options:\n"+
 			"    -cp, --configProvider           Indicates to use Configuration Provider service at specified URL.\n"+
 			"                                    URL Format: {type}.{protocol}://{host}:{port} ex: consul.http://localhost:8500\n"+
-			"    -cc, --commonConfig             Takes the URI that specifies where the common configuration is pulled from when\n"+
+			"    -cc, --commonConfig             Takes the location to specifies where the common configuration is loaded from when\n"+
 			"                                    not using the Configuration Provider\n"+
 			"    -o, --overwrite                 Overwrite configuration in provider with local configuration\n"+
 			"                                    *** Use with cation *** Use will clobber existing settings in provider,\n"+

--- a/bootstrap/flags/flags_test.go
+++ b/bootstrap/flags/flags_test.go
@@ -31,6 +31,7 @@ func TestNewAllFlags(t *testing.T) {
 	expectedProfile := "docker"
 	expectedConfigDirectory := "/res"
 	expectedFileName := "config.toml"
+	expectedCommonConfig := "config.yaml"
 
 	actual := newSUT(
 		[]string{
@@ -39,6 +40,7 @@ func TestNewAllFlags(t *testing.T) {
 			"-p=" + expectedProfile,
 			"-cd=" + expectedConfigDirectory,
 			"-cf=" + expectedFileName,
+			"-cc=" + expectedCommonConfig,
 		},
 	)
 
@@ -47,6 +49,7 @@ func TestNewAllFlags(t *testing.T) {
 	assert.Equal(t, expectedProfile, actual.Profile())
 	assert.Equal(t, expectedConfigDirectory, actual.ConfigDirectory())
 	assert.Equal(t, expectedFileName, actual.ConfigFileName())
+	assert.Equal(t, expectedCommonConfig, actual.CommonConfig())
 }
 
 func TestNewDefaultsNoFlags(t *testing.T) {
@@ -58,6 +61,7 @@ func TestNewDefaultsNoFlags(t *testing.T) {
 	assert.Equal(t, "", actual.Profile())
 	assert.Equal(t, "", actual.ConfigDirectory())
 	assert.Equal(t, DefaultConfigFile, actual.ConfigFileName())
+	assert.Equal(t, "", actual.CommonConfig())
 }
 
 func TestNewDefaultForCP(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/stretchr/testify v1.8.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -68,5 +69,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
[docs PR](https://github.com/edgexfoundry/edgex-docs/pull/990)

## Testing Instructions
<!-- How can the reviewers test your change? -->
**Non-secure mode testing **
1. set the environment variable for non-secure testing `export EDGEX_SECURITY_SECRET_STORE=false`
2. run the latest compose builder `make run no-secty` to start core services
3. stop core data
4. remove the core data configuration in consul
5. modify local go-mod in edgex-go to use bootstrap from [this branch](https://github.com/ejlee3/go-mod-bootstrap/tree/common-config-flag)
7. build core data `make data`
9. run core-data locally and ensure that the configuration loads `cd cmd/core-data` and `./core-data -cc ../core-common-config-bootstrapper/res/configuration.yaml`
10. Verify that the core data configuration and common config were loaded using curl `curl http://localhost:59880/api/v2/config | json_pp`

**secure mode testing **
Repeat the above steps with `EDGEX_SECRUITY_SECRETS_STORE=true`, run all services in secure mode, and run core data with `sudo` 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->