### PR TITLE
fix: Rework merge of configs to better handle empty values

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -617,7 +618,7 @@ func GetConfigFileLocation(lc logger.LoggingClient, flags flags.Common) string {
 	profileDir := environment.GetProfileDir(lc, flags.Profile())
 	configFileName := environment.GetConfigFileName(lc, flags.ConfigFileName())
 
-	return configDir + utils.PathSep + profileDir + configFileName
+	return filepath.Join(configDir, profileDir, configFileName)
 }
 
 // listenForChanges leverages the Configuration Provider client's WatchForChanges() method to receive changes to and update the

--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -222,6 +222,22 @@ func TestLoadCommonConfig(t *testing.T) {
 			}
 			if tc.serviceType == config.ServiceTypeApp || tc.serviceType == config.ServiceTypeDevice {
 				providerClientMock.On("GetConfiguration", &serviceConfigMock).Return(tc.serviceTypeConfig, tc.getConfigErr).Once()
+				var configKeys []string
+				switch tc.serviceType {
+				case config.ServiceTypeApp:
+					configKeys = []string{
+						"edgex/v3/core-common-config-bootstrapper/app-services/Writable/StoreAndForward/Enabled",
+						"edgex/v3/core-common-config-bootstrapper/app-services/Writable/StoreAndForward/RetryInterval",
+						"edgex/v3/core-common-config-bootstrapper/app-services/Writable/StoreAndForward/MaxRetryCount",
+					}
+				case config.ServiceTypeDevice:
+					configKeys = []string{
+						"edgex/v3/core-common-config-bootstrapper/device-services/Writable/Telemetry/Metrics/EventsSent",
+						"edgex/v3/core-common-config-bootstrapper/device-services/Writable/Telemetry/Metrics/ReadingsSent",
+					}
+				}
+
+				providerClientMock.On("GetConfigurationKeys", mock.Anything).Return(configKeys, nil).Once()
 			}
 			// call load common config
 			err = proc.loadCommonConfig(common.ConfigStemAll, getAccessToken, &ProviderInfo{}, &serviceConfigMock, tc.serviceType, providerClientCreator)

--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -17,7 +17,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -378,4 +380,22 @@ func TestIsPrivateConfig(t *testing.T) {
 			require.NotNil(t, cancel)
 		})
 	}
+}
+
+func TestGetConfigFileLocation(t *testing.T) {
+	dir := "myRes"
+	profile := "myProfile"
+	file := "myFile.yaml"
+	expected := filepath.Join(dir, profile, file)
+	defer os.Clearenv()
+
+	lc := logger.NewMockClient()
+	flags := flags.New()
+
+	os.Setenv("EDGEX_CONFIG_DIR", dir)
+	os.Setenv("EDGEX_PROFILE", profile)
+	os.Setenv("EDGEX_CONFIG_FILE", file)
+
+	actual := GetConfigFileLocation(lc, flags)
+	assert.Equal(t, expected, actual)
 }

--- a/bootstrap/utils/utils.go
+++ b/bootstrap/utils/utils.go
@@ -77,19 +77,19 @@ func RemoveUnusedSettings(src any, baseKey string, usedSettingKeys map[string]an
 		return nil, fmt.Errorf("could not create map from %T: %s", src, err.Error())
 	}
 
-	removeMapUnusedSettings(srcMap, baseKey, usedSettingKeys)
+	removeUnusedSettingsFromMap(srcMap, baseKey, usedSettingKeys)
 
 	return srcMap, nil
 }
 
 // removeMapUnusedSettings iterates over a map and removes any settings not in list of valid keys
-func removeMapUnusedSettings(target map[string]any, baseKey string, validKeys map[string]any) {
+func removeUnusedSettingsFromMap(target map[string]any, baseKey string, validKeys map[string]any) {
 	var removeKeys []string
 	for key, value := range target {
 		nextBaseKey := BuildBaseKey(baseKey, key)
 		sub, ok := value.(map[string]any)
 		if ok {
-			removeMapUnusedSettings(sub, nextBaseKey, validKeys)
+			removeUnusedSettingsFromMap(sub, nextBaseKey, validKeys)
 			if len(sub) == 0 {
 				removeKeys = append(removeKeys, key)
 			}

--- a/bootstrap/utils/utils.go
+++ b/bootstrap/utils/utils.go
@@ -17,8 +17,10 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
+	"strings"
 )
+
+const PathSep = "/"
 
 // ConvertToMap uses json to marshal and unmarshal a target type into a map
 func ConvertToMap(target any, m *map[string]any) error {
@@ -68,23 +70,36 @@ func MergeMaps(dest map[string]any, src map[string]any) {
 	}
 }
 
-// RemoveZeroValues iterates over a map and removes any zero values it may have
-func RemoveZeroValues(target map[string]any) {
+func RemoveUnusedSettings(src any, baseKey string, usedSettingKeys map[string]any) (map[string]any, error) {
+	srcMap := make(map[string]any)
+
+	if err := ConvertToMap(src, &srcMap); err != nil {
+		return nil, fmt.Errorf("could not create map from %T: %s", src, err.Error())
+	}
+
+	removeMapUnusedSettings(srcMap, baseKey, usedSettingKeys)
+
+	return srcMap, nil
+}
+
+// removeMapUnusedSettings iterates over a map and removes any settings not in list of valid keys
+func removeMapUnusedSettings(target map[string]any, baseKey string, validKeys map[string]any) {
 	var removeKeys []string
 	for key, value := range target {
+		nextBaseKey := BuildBaseKey(baseKey, key)
 		sub, ok := value.(map[string]any)
 		if ok {
-			RemoveZeroValues(sub)
+			removeMapUnusedSettings(sub, nextBaseKey, validKeys)
 			if len(sub) == 0 {
 				removeKeys = append(removeKeys, key)
 			}
 			continue
 		}
 
-		if value == nil || reflect.ValueOf(value).IsZero() {
+		_, exists := validKeys[nextBaseKey]
+		if !exists {
 			removeKeys = append(removeKeys, key)
 		}
-
 	}
 
 	for _, key := range removeKeys {
@@ -92,21 +107,25 @@ func RemoveZeroValues(target map[string]any) {
 	}
 }
 
-// MergeValues combines src (zeros removed) with the dest
+// MergeValues combines src with the dest.
 func MergeValues(dest any, src any) error {
+	var ok bool
 	var destMap, srcMap map[string]any
 
-	if err := ConvertToMap(dest, &destMap); err != nil {
-		return fmt.Errorf("could not create destination map from %T: %s", dest, err.Error())
+	destMap, ok = dest.(map[string]any)
+	if !ok {
+		if err := ConvertToMap(dest, &destMap); err != nil {
+			return fmt.Errorf("could not create destination map from %T: %s", dest, err.Error())
+		}
 	}
 
-	if err := ConvertToMap(src, &srcMap); err != nil {
-		return fmt.Errorf("could not source create map from %T: %s", src, err.Error())
+	srcMap, ok = src.(map[string]any)
+	if !ok {
+		if err := ConvertToMap(src, &srcMap); err != nil {
+			return fmt.Errorf("could not source create map from %T: %s", src, err.Error())
+		}
 	}
 
-	// remove zero values from the source to prevent overwriting items in the destination
-	// and merge the src with dest
-	RemoveZeroValues(srcMap)
 	MergeMaps(destMap, srcMap)
 
 	// convert the map back to a dest
@@ -115,4 +134,18 @@ func MergeValues(dest any, src any) error {
 	}
 
 	return nil
+}
+
+func StringSliceToMap(src []string) map[string]any {
+	result := make(map[string]any)
+
+	for _, value := range src {
+		result[value] = nil
+	}
+
+	return result
+}
+
+func BuildBaseKey(keys ...string) string {
+	return strings.Join(keys, PathSep)
 }

--- a/bootstrap/utils/utils.go
+++ b/bootstrap/utils/utils.go
@@ -95,7 +95,6 @@ func removeUnusedSettingsFromMap(target map[string]any, baseKey string, validKey
 			}
 			continue
 		}
-
 		_, exists := validKeys[nextBaseKey]
 		if !exists {
 			removeKeys = append(removeKeys, key)


### PR DESCRIPTION
fixes #501

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
Build Core Data/ App Template/ Device Simple with this branch
Run each and verify the following
- Configs are loaded from file and pushed to Config Provider as expected
-   - Common configs and private configs merged without losing empty setting in private config
- Configs are loaded from Config Provider as expected
   - Common configs and private configs merged without losing empty setting in private config
- Writable changes are handled at all levels 
    - Private
    - All Common
    - App or Device common
 
## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->