### PR TITLE
refactor!: Rework SecretProvider interface so App/Device Services have limited API

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -111,7 +111,7 @@ func RunAndReturnWaitGroup(
 
 	envVars := environment.NewVariables(lc)
 
-	var secretProvider interfaces.SecretProvider
+	var secretProvider interfaces.SecretProviderExt
 	if useSecretProvider {
 		secretProvider, err = secret.NewSecretProvider(serviceConfig, envVars, ctx, startupTimer, dic, serviceKey)
 		if err != nil {
@@ -180,7 +180,7 @@ func RunAndReturnWaitGroup(
 		// opportunity for the MetricsManager to have been created.
 		metricsManager := container.MetricsManagerFrom(dic.Get)
 		if metricsManager != nil {
-			secretProvider := container.SecretProviderFrom(dic.Get)
+			secretProvider := container.SecretProviderExtFrom(dic.Get)
 			if secretProvider != nil {
 				metrics := secretProvider.GetMetricsToRegister()
 				registerMetrics(metricsManager, metrics, lc)

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -115,7 +115,7 @@ func (cp *Processor) Process(
 	serviceType string,
 	configStem string,
 	serviceConfig interfaces.Configuration,
-	secretProvider interfaces.SecretProvider) error {
+	secretProvider interfaces.SecretProviderExt) error {
 
 	cp.overwriteConfig = cp.flags.OverwriteConfig()
 	configProviderUrl := cp.flags.ConfigProviderUrl()
@@ -407,7 +407,7 @@ func (cp *Processor) loadCommonConfigFromFile(
 	return err
 }
 
-func (cp *Processor) getAccessTokenCallback(serviceKey string, secretProvider interfaces.SecretProvider, err error, configProviderInfo *ProviderInfo) (types.GetAccessTokenCallback, error) {
+func (cp *Processor) getAccessTokenCallback(serviceKey string, secretProvider interfaces.SecretProviderExt, err error, configProviderInfo *ProviderInfo) (types.GetAccessTokenCallback, error) {
 	var accessToken string
 	var getAccessToken types.GetAccessTokenCallback
 
@@ -827,7 +827,7 @@ func (cp *Processor) applyWritableUpdates(serviceConfig interfaces.Configuration
 	case currentInsecureSecrets != nil &&
 		!reflect.DeepEqual(currentInsecureSecrets, previousInsecureSecrets):
 		lc.Info("Insecure Secrets have been updated")
-		secretProvider := container.SecretProviderFrom(cp.dic.Get)
+		secretProvider := container.SecretProviderExtFrom(cp.dic.Get)
 		if secretProvider != nil {
 			// Find the updated secret's path and perform call backs.
 			updatedSecrets := getSecretNamesChanged(previousInsecureSecrets, currentInsecureSecrets)

--- a/bootstrap/container/secret.go
+++ b/bootstrap/container/secret.go
@@ -33,3 +33,17 @@ func SecretProviderFrom(get di.Get) interfaces.SecretProvider {
 
 	return provider
 }
+
+// SecretProviderExtName contains the name of the interfaces.SecretProviderExt implementation in the DIC.
+var SecretProviderExtName = di.TypeInstanceToName((*interfaces.SecretProvider)(nil))
+
+// SecretProviderExtFrom helper function queries the DIC and returns the interfaces.SecretProviderExt
+// implementation.
+func SecretProviderExtFrom(get di.Get) interfaces.SecretProviderExt {
+	provider, ok := get(SecretProviderExtName).(interfaces.SecretProviderExt)
+	if !ok {
+		return nil
+	}
+
+	return provider
+}

--- a/bootstrap/handlers/auth_middleware.go
+++ b/bootstrap/handlers/auth_middleware.go
@@ -43,7 +43,7 @@ import (
 //
 // For typical usage, it is preferred to use AutoConfigAuthenticationFunc which
 // will automatically select between a real and a fake JWT validation handler.
-func VaultAuthenticationHandlerFunc(secretProvider interfaces.SecretProvider, lc logger.LoggingClient) func(inner http.HandlerFunc) http.HandlerFunc {
+func VaultAuthenticationHandlerFunc(secretProvider interfaces.SecretProviderExt, lc logger.LoggingClient) func(inner http.HandlerFunc) http.HandlerFunc {
 	return func(inner http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			authHeader := r.Header.Get("Authorization")
@@ -89,7 +89,7 @@ func NilAuthenticationHandlerFunc() func(inner http.HandlerFunc) http.HandlerFun
 // to disable JWT validation.  This might be wanted for an EdgeX
 // adopter that wanted to only validate JWT's at the proxy layer,
 // or as an escape hatch for a caller that cannot authenticate.
-func AutoConfigAuthenticationFunc(secretProvider interfaces.SecretProvider, lc logger.LoggingClient) func(inner http.HandlerFunc) http.HandlerFunc {
+func AutoConfigAuthenticationFunc(secretProvider interfaces.SecretProviderExt, lc logger.LoggingClient) func(inner http.HandlerFunc) http.HandlerFunc {
 	// Golang standard library treats an error as false
 	disableJWTValidation, _ := strconv.ParseBool(os.Getenv("EDGEX_DISABLE_JWT_VALIDATION"))
 	authenticationHook := NilAuthenticationHandlerFunc()

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -58,7 +58,7 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 	lc := container.LoggingClientFrom(dic.Get)
 	config := container.ConfigurationFrom(dic.Get)
 	cb.registry = container.RegistryFrom(dic.Get)
-	jwtSecretProvider := secret.NewJWTSecretProvider(container.SecretProviderFrom(dic.Get))
+	jwtSecretProvider := secret.NewJWTSecretProvider(container.SecretProviderExtFrom(dic.Get))
 
 	for serviceKey, serviceInfo := range config.GetBootstrap().Clients {
 		var url string

--- a/bootstrap/interfaces/secret.go
+++ b/bootstrap/interfaces/secret.go
@@ -12,12 +12,11 @@
  * the License.
  *******************************************************************************/package interfaces
 
-import (
-	"time"
-)
+import "time"
 
 // SecretProvider defines the contract for secret provider implementations that
-// allow secrets to be retrieved/stored from/to a services Secret Store.
+// allow secrets to be retrieved/stored from/to a services Secret Store and other secret related APIs.
+// This interface is limited to the APIs that individual service code need.
 type SecretProvider interface {
 	// StoreSecret stores new secrets into the service's SecretStore at the specified secretName.
 	StoreSecret(secretName string, secrets map[string]string) error
@@ -25,15 +24,8 @@ type SecretProvider interface {
 	// GetSecret retrieves secrets from the service's SecretStore at the specified secretName.
 	GetSecret(secretName string, keys ...string) (map[string]string, error)
 
-	// SecretsUpdated sets the secrets last updated time to current time.
-	SecretsUpdated()
-
 	// SecretsLastUpdated returns the last time secrets were updated
 	SecretsLastUpdated() time.Time
-
-	// GetAccessToken return an access token for the specified token type and service key.
-	// Service key is use as the access token role which must have be previously setup.
-	GetAccessToken(tokenType string, serviceKey string) (string, error)
 
 	// ListSecretNames returns a list of secretNames for the current service from an insecure/secure secret store.
 	ListSecretNames() ([]string, error)
@@ -44,11 +36,24 @@ type SecretProvider interface {
 	// RegisteredSecretUpdatedCallback registers a callback for a secret.
 	RegisteredSecretUpdatedCallback(secretName string, callback func(path string)) error
 
-	// SecretUpdatedAtSecretName performs updates and callbacks for an updated secret or secretName.
-	SecretUpdatedAtSecretName(secretName string)
-
 	// DeregisterSecretUpdatedCallback removes a secret's registered callback secretName.
 	DeregisterSecretUpdatedCallback(secretName string)
+}
+
+// SecretProviderExt defines the extended contract for secret provider implementations that
+// provide additional APIs needed only from the bootstrap code.
+type SecretProviderExt interface {
+	SecretProvider
+
+	// SecretsUpdated sets the secrets last updated time to current time.
+	SecretsUpdated()
+
+	// GetAccessToken return an access token for the specified token type and service key.
+	// Service key is use as the access token role which must have be previously setup.
+	GetAccessToken(tokenType string, serviceKey string) (string, error)
+
+	// SecretUpdatedAtSecretName performs updates and callbacks for an updated secret or secretName.
+	SecretUpdatedAtSecretName(secretName string)
 
 	// GetMetricsToRegister returns all metric objects that needs to be registered.
 	GetMetricsToRegister() map[string]interface{}

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -45,7 +45,7 @@ func createRegistryClient(
 	var accessToken string
 	var getAccessToken registryTypes.GetAccessTokenCallback
 
-	secretProvider := container.SecretProviderFrom(dic.Get)
+	secretProvider := container.SecretProviderExtFrom(dic.Get)
 	// secretProvider will be nil if not configured to be used. In that case, no access token required.
 	if secretProvider != nil {
 		// Define the callback function to retrieve the Access Token

--- a/bootstrap/secret/jwtprovider.go
+++ b/bootstrap/secret/jwtprovider.go
@@ -14,10 +14,10 @@ import (
 )
 
 type jwtSecretProvider struct {
-	secretProvider interfaces.SecretProvider
+	secretProvider interfaces.SecretProviderExt
 }
 
-func NewJWTSecretProvider(secretProvider interfaces.SecretProvider) clientInterfaces.AuthenticationInjector {
+func NewJWTSecretProvider(secretProvider interfaces.SecretProviderExt) clientInterfaces.AuthenticationInjector {
 	return &jwtSecretProvider{
 		secretProvider: secretProvider,
 	}

--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -52,10 +52,10 @@ func NewSecretProvider(
 	ctx context.Context,
 	startupTimer startup.Timer,
 	dic *di.Container,
-	serviceKey string) (interfaces.SecretProvider, error) {
+	serviceKey string) (interfaces.SecretProviderExt, error) {
 	lc := container.LoggingClientFrom(dic.Get)
 
-	var provider interfaces.SecretProvider
+	var provider interfaces.SecretProviderExt
 
 	switch IsSecurityEnabled() {
 	case true:
@@ -134,7 +134,12 @@ func NewSecretProvider(
 	}
 
 	dic.Update(di.ServiceConstructorMap{
+		// Must put the SecretProvider instance in the DIC for both the standard API use by service code
+		// and the extended API used by boostrap code
 		container.SecretProviderName: func(get di.Get) interface{} {
+			return provider
+		},
+		container.SecretProviderExtName: func(get di.Get) interface{} {
 			return provider
 		},
 	})


### PR DESCRIPTION
BREAKING CHANGE: Service that need full SecretProvider API now use SecretProviderExt. Extra APIs have been removed for App/Device Services.

closes #398

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
 https://github.com/edgexfoundry/edgex-docs/pull/1020

## Testing Instructions
See https://github.com/edgexfoundry/edgex-go/pull/4510 testing

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->