### PR TITLE
feat: Add -d/--dev common command-line flag to put service in Dev Mode

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -276,7 +276,7 @@ func (cp *Processor) Process(
 		}
 
 		if config.Clients != nil {
-			for _, client := range config.Clients {
+			for _, client := range *config.Clients {
 				client.Host = host
 			}
 		}

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -253,6 +253,35 @@ func (cp *Processor) Process(
 	// Now that configuration has been loaded and overrides applied the log level can be set as configured.
 	err = cp.lc.SetLogLevel(serviceConfig.GetLogLevel())
 
+	if cp.flags.InDevMode() {
+		// Dev mode is for when running service with Config Provider in hybrid mode (all other service running in Docker).
+		// All the host values are set to the docker names in the common configuration, so must be overridden here with "localhost"
+		host := "localhost"
+		config := serviceConfig.GetBootstrap()
+
+		if config.Service != nil {
+			config.Service.Host = host
+		}
+
+		if config.MessageBus != nil {
+			config.MessageBus.Host = host
+		}
+
+		if config.Registry != nil {
+			config.Registry.Host = host
+		}
+
+		if config.Database != nil {
+			config.Database.Host = host
+		}
+
+		if config.Clients != nil {
+			for _, client := range config.Clients {
+				client.Host = host
+			}
+		}
+	}
+
 	return err
 }
 

--- a/bootstrap/config/configmock_test.go
+++ b/bootstrap/config/configmock_test.go
@@ -64,8 +64,7 @@ func (c *ConfigurationMockStruct) UpdateWritableFromRaw(rawWritable interface{})
 
 func (c *ConfigurationMockStruct) GetBootstrap() config.BootstrapConfiguration {
 	return config.BootstrapConfiguration{
-		Service:  c.transformToBootstrapServiceInfo(),
-		Registry: c.Registry,
+		Registry: &c.Registry,
 	}
 }
 
@@ -83,10 +82,6 @@ func (c *ConfigurationMockStruct) GetInsecureSecrets() config.InsecureSecrets {
 
 func (c *ConfigurationMockStruct) GetTelemetryInfo() *config.TelemetryInfo {
 	return &c.Writable.Telemetry
-}
-
-func (c *ConfigurationMockStruct) transformToBootstrapServiceInfo() config.ServiceInfo {
-	return config.ServiceInfo{}
 }
 
 func (c *ConfigurationMockStruct) GetWritablePtr() any {

--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -30,6 +30,7 @@ const (
 type Common interface {
 	OverwriteConfig() bool
 	UseRegistry() bool
+	InDevMode() bool
 	ConfigProviderUrl() string
 	Profile() string
 	ConfigDirectory() string
@@ -45,6 +46,7 @@ type Default struct {
 	additionalUsage   string
 	overwriteConfig   bool
 	useRegistry       bool
+	devMode           bool
 	configProviderUrl string
 	commonConfig      string
 	profile           string
@@ -97,6 +99,8 @@ func (d *Default) Parse(arguments []string) {
 	d.FlagSet.StringVar(&d.configDir, "cd", "", "")
 	d.FlagSet.BoolVar(&d.useRegistry, "registry", false, "")
 	d.FlagSet.BoolVar(&d.useRegistry, "r", false, "")
+	d.FlagSet.BoolVar(&d.devMode, "dev", false, "")
+	d.FlagSet.BoolVar(&d.devMode, "d", false, "")
 
 	d.FlagSet.Usage = d.helpCallback
 
@@ -115,6 +119,11 @@ func (d *Default) OverwriteConfig() bool {
 // UseRegistry returns whether the Registry should be used or not
 func (d *Default) UseRegistry() bool {
 	return d.useRegistry
+}
+
+// InDevMode returns whether running in dev mode or not
+func (d *Default) InDevMode() bool {
+	return d.devMode
 }
 
 // ConfigProviderUrl returns the url for the Configuration Provider, if one was specified.
@@ -163,6 +172,8 @@ func (d *Default) helpCallback() {
 			"    -p, --profile <name>            Indicate configuration profile other than default\n"+
 			"    -cd, --configDir                Specify local configuration directory\n"+
 			"    -r, --registry                  Indicates service should use Registry.\n"+
+			"    -d, --dev                       Indicates service to run in developer mode which causes Host configuration values to be overridden.\n"+
+			"                                    with `localhost`. This is so that it will run with other services running in Docker (aka hybrid mode)\n"+
 			"%s\n"+
 			"Common Options:\n"+
 			"	-h, --help                      Show this message\n",

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -37,12 +37,15 @@ import (
 
 // ClientsBootstrap contains data to boostrap the configured clients
 type ClientsBootstrap struct {
-	registry registry.Client
+	registry  registry.Client
+	inDevMode bool
 }
 
 // NewClientsBootstrap is a factory method that returns the initialized "ClientsBootstrap" receiver struct.
-func NewClientsBootstrap() *ClientsBootstrap {
-	return &ClientsBootstrap{}
+func NewClientsBootstrap(devMode bool) *ClientsBootstrap {
+	return &ClientsBootstrap{
+		inDevMode: devMode,
+	}
 }
 
 // BootstrapHandler fulfills the BootstrapHandler contract.
@@ -156,7 +159,7 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 }
 
 func (cb *ClientsBootstrap) getClientUrl(serviceKey string, defaultUrl string, startupTimer startup.Timer, lc logger.LoggingClient) (string, error) {
-	if cb.registry == nil {
+	if cb.registry == nil || cb.inDevMode {
 		lc.Infof("Using REST for '%s' clients @ %s", serviceKey, defaultUrl)
 		return defaultUrl, nil
 	}

--- a/bootstrap/handlers/clients_test.go
+++ b/bootstrap/handlers/clients_test.go
@@ -173,7 +173,7 @@ func TestClientsBootstrapHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			clients := make(map[string]*config.ClientInfo)
+			clients := make(config.ClientsCollection)
 
 			if test.CoreDataClientInfo != nil {
 				clients[common.CoreDataServiceKey] = test.CoreDataClientInfo
@@ -199,7 +199,7 @@ func TestClientsBootstrapHandler(t *testing.T) {
 				Service: &config.ServiceInfo{
 					RequestTimeout: "30s",
 				},
-				Clients:    clients,
+				Clients:    &clients,
 				MessageBus: &config.MessageBusInfo{},
 			}
 
@@ -309,7 +309,7 @@ func TestCommandMessagingClientErrors(t *testing.T) {
 
 			mockMessaging := &messagingMocks.MessageClient{}
 
-			clients := make(map[string]*config.ClientInfo)
+			clients := make(config.ClientsCollection)
 			clients[common.CoreCommandServiceKey] = &config.ClientInfo{
 				UseMessageBus: true,
 			}
@@ -318,7 +318,7 @@ func TestCommandMessagingClientErrors(t *testing.T) {
 				Service: &config.ServiceInfo{
 					RequestTimeout: test.TimeoutDuration,
 				},
-				Clients: clients,
+				Clients: &clients,
 			}
 
 			configMock := &mocks.Configuration{}

--- a/bootstrap/handlers/clients_test.go
+++ b/bootstrap/handlers/clients_test.go
@@ -173,33 +173,34 @@ func TestClientsBootstrapHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			clients := make(map[string]config.ClientInfo)
+			clients := make(map[string]*config.ClientInfo)
 
 			if test.CoreDataClientInfo != nil {
-				clients[common.CoreDataServiceKey] = *test.CoreDataClientInfo
+				clients[common.CoreDataServiceKey] = test.CoreDataClientInfo
 			}
 
 			if test.CommandClientInfo != nil {
-				clients[common.CoreCommandServiceKey] = *test.CommandClientInfo
+				clients[common.CoreCommandServiceKey] = test.CommandClientInfo
 			}
 
 			if test.MetadataClientInfo != nil {
-				clients[common.CoreMetaDataServiceKey] = *test.MetadataClientInfo
+				clients[common.CoreMetaDataServiceKey] = test.MetadataClientInfo
 			}
 
 			if test.NotificationClientInfo != nil {
-				clients[common.SupportNotificationsServiceKey] = *test.NotificationClientInfo
+				clients[common.SupportNotificationsServiceKey] = test.NotificationClientInfo
 			}
 
 			if test.SchedulerClientInfo != nil {
-				clients[common.SupportSchedulerServiceKey] = *test.SchedulerClientInfo
+				clients[common.SupportSchedulerServiceKey] = test.SchedulerClientInfo
 			}
 
 			bootstrapConfig := config.BootstrapConfiguration{
-				Service: config.ServiceInfo{
+				Service: &config.ServiceInfo{
 					RequestTimeout: "30s",
 				},
-				Clients: clients,
+				Clients:    clients,
+				MessageBus: &config.MessageBusInfo{},
 			}
 
 			configMock := &mocks.Configuration{}
@@ -223,7 +224,7 @@ func TestClientsBootstrapHandler(t *testing.T) {
 				},
 			})
 
-			actualResult := NewClientsBootstrap().BootstrapHandler(context.Background(), &sync.WaitGroup{}, startupTimer, dic)
+			actualResult := NewClientsBootstrap(false).BootstrapHandler(context.Background(), &sync.WaitGroup{}, startupTimer, dic)
 			require.Equal(t, actualResult, test.ExpectedResult)
 			if test.ExpectedResult == false {
 				return
@@ -308,13 +309,13 @@ func TestCommandMessagingClientErrors(t *testing.T) {
 
 			mockMessaging := &messagingMocks.MessageClient{}
 
-			clients := make(map[string]config.ClientInfo)
-			clients[common.CoreCommandServiceKey] = config.ClientInfo{
+			clients := make(map[string]*config.ClientInfo)
+			clients[common.CoreCommandServiceKey] = &config.ClientInfo{
 				UseMessageBus: true,
 			}
 
 			bootstrapConfig := config.BootstrapConfiguration{
-				Service: config.ServiceInfo{
+				Service: &config.ServiceInfo{
 					RequestTimeout: test.TimeoutDuration,
 				},
 				Clients: clients,
@@ -340,7 +341,7 @@ func TestCommandMessagingClientErrors(t *testing.T) {
 			})
 
 			startupTimer := startup.NewTimer(1, 1)
-			actualResult := NewClientsBootstrap().BootstrapHandler(context.Background(), &sync.WaitGroup{}, startupTimer, dic)
+			actualResult := NewClientsBootstrap(false).BootstrapHandler(context.Background(), &sync.WaitGroup{}, startupTimer, dic)
 			require.False(t, actualResult)
 
 			mockLogger.AssertNumberOfCalls(t, "Errorf", 1)

--- a/bootstrap/handlers/messaging.go
+++ b/bootstrap/handlers/messaging.go
@@ -47,7 +47,7 @@ func MessagingBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupT
 	}
 
 	// Make sure the MessageBus password is not leaked into the Service Config that can be retrieved via the /config endpoint
-	messageBusInfo := deepCopy(messageBus)
+	messageBusInfo := deepCopy(*messageBus)
 
 	if len(messageBusInfo.AuthMode) > 0 &&
 		!strings.EqualFold(strings.TrimSpace(messageBusInfo.AuthMode), boostrapMessaging.AuthModeNone) {

--- a/bootstrap/handlers/messaging_test.go
+++ b/bootstrap/handlers/messaging_test.go
@@ -84,7 +84,7 @@ func TestBootstrapHandler(t *testing.T) {
 			providerMock.On("GetSecret", test.MessageBus.SecretName).Return(usernameSecretData, nil)
 			configMock := &mocks.Configuration{}
 			configMock.On("GetBootstrap").Return(config.BootstrapConfiguration{
-				MessageBus: test.MessageBus,
+				MessageBus: &test.MessageBus,
 			})
 
 			dic.Update(di.ServiceConstructorMap{

--- a/bootstrap/handlers/metrics_test.go
+++ b/bootstrap/handlers/metrics_test.go
@@ -50,7 +50,9 @@ func TestServiceMetrics_BootstrapHandler(t *testing.T) {
 
 			mockMessagingClient := &mocks.MessageClient{}
 			mockConfiguration := &mocks2.Configuration{}
-			mockConfiguration.On("GetBootstrap").Return(config.BootstrapConfiguration{})
+			mockConfiguration.On("GetBootstrap").Return(config.BootstrapConfiguration{
+				MessageBus: &config.MessageBusInfo{},
+			})
 
 			dic := di.NewContainer(di.ServiceConstructorMap{
 				container.LoggingClientInterfaceName: func(get di.Get) interface{} {

--- a/bootstrap/registration/registry_test.go
+++ b/bootstrap/registration/registry_test.go
@@ -81,8 +81,8 @@ func (ut unitTestConfiguration) UpdateWritableFromRaw(_ interface{}) bool {
 
 func (ut unitTestConfiguration) GetBootstrap() config.BootstrapConfiguration {
 	return config.BootstrapConfiguration{
-		Service:  ut.Service,
-		Registry: ut.Registry,
+		Service:  &ut.Service,
+		Registry: &ut.Registry,
 	}
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -226,11 +226,12 @@ type InsecureSecretsInfo struct {
 
 // BootstrapConfiguration defines the configuration elements required by the bootstrap.
 type BootstrapConfiguration struct {
-	Clients      map[string]ClientInfo
-	Service      ServiceInfo
+	Clients      map[string]*ClientInfo
+	Service      *ServiceInfo
 	Config       ConfigProviderInfo
-	Registry     RegistryInfo
-	MessageBus   MessageBusInfo
+	Registry     *RegistryInfo
+	MessageBus   *MessageBusInfo
+	Database     *Database
 	ExternalMQTT ExternalMQTTInfo
 }
 

--- a/config/types.go
+++ b/config/types.go
@@ -224,15 +224,18 @@ type InsecureSecretsInfo struct {
 	SecretData map[string]string
 }
 
+// ClientsCollection is a collection of Client information for communicating to dependent clients.
+type ClientsCollection map[string]*ClientInfo
+
 // BootstrapConfiguration defines the configuration elements required by the bootstrap.
 type BootstrapConfiguration struct {
-	Clients      map[string]*ClientInfo
+	Clients      *ClientsCollection
 	Service      *ServiceInfo
-	Config       ConfigProviderInfo
+	Config       *ConfigProviderInfo
 	Registry     *RegistryInfo
 	MessageBus   *MessageBusInfo
 	Database     *Database
-	ExternalMQTT ExternalMQTTInfo
+	ExternalMQTT *ExternalMQTTInfo
 }
 
 // MessageBusInfo provides parameters related to connecting to the EdgeX MessageBus


### PR DESCRIPTION
Dev Mode is used when running service locally with the other services running in Docker (aka hybrid mode). This causes all the `Host` settings pulled from common configuration to be overridden with the value `localhost`.

closes #509

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
 TBD

## Testing Instructions
Use in edgex-go, app sdk and device sdk and make appropriate code changes
Build and run core/support services with "-cp -d" options with other services running in docker
Verify service bootstraps properly
Build and run device-simple with "-cp -d" options with other services running in docker
Verify service bootstraps properly
Build and run app-template with "-cp -d" options with other services running in docker
Verify service bootstraps properly


## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->