### PR TITLE
fix: InsecureSecrets change detection

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -831,9 +831,13 @@ func (cp *Processor) isPrivateOverride(previous any, updated any, privateConfigC
 
 func (cp *Processor) applyWritableUpdates(serviceConfig interfaces.Configuration, raw any) {
 	lc := cp.lc
-	previousInsecureSecrets := serviceConfig.GetInsecureSecrets()
 	previousLogLevel := serviceConfig.GetLogLevel()
 	previousTelemetryInterval := serviceConfig.GetTelemetryInfo().Interval
+
+	var previousInsecureSecrets config.InsecureSecrets
+	if err := utils.DeepCopy(serviceConfig.GetInsecureSecrets(), &previousInsecureSecrets); err != nil {
+		lc.Errorf("failed to deep copy insecure secrets: %v", err)
+	}
 
 	if err := utils.MergeValues(serviceConfig.GetWritablePtr(), raw); err != nil {
 		lc.Errorf("failed to apply Writable change to service configuration: %v", err)

--- a/bootstrap/utils/utils.go
+++ b/bootstrap/utils/utils.go
@@ -148,3 +148,16 @@ func StringSliceToMap(src []string) map[string]any {
 func BuildBaseKey(keys ...string) string {
 	return strings.Join(keys, PathSep)
 }
+
+// DeepCopy creates a deep copy/clone of a struct by using json to marshal the original struct, and then unmarshal it
+// back into the new copy. Note that this will only copy the exported fields.
+func DeepCopy(src any, dest any) error {
+	jsonBytes, err := json.Marshal(src)
+	if err != nil {
+		return fmt.Errorf("could not marshal %T to JSON: %v", src, err)
+	}
+	if err = json.Unmarshal(jsonBytes, &dest); err != nil {
+		return fmt.Errorf("could not unmarshal JSON (from %T) into type %T: %v", src, dest, err)
+	}
+	return nil
+}

--- a/bootstrap/utils/utils_test.go
+++ b/bootstrap/utils/utils_test.go
@@ -231,3 +231,50 @@ func assertMapSettingValueNotExist(t *testing.T, actual map[string]any, actualPa
 
 	return true
 }
+
+func TestDeepCopy(t *testing.T) {
+	// create some nested data
+	orig := ConfigurationMockStruct{
+		Writable: WritableInfo{
+			LogLevel: "INFO",
+		},
+		Registry: config.RegistryInfo{
+			Host: "localhost",
+			Port: 8500,
+			Type: "consul",
+		},
+		Clients: map[string]config.ClientInfo{
+			"a": {
+				Host:          "localhost",
+				Port:          9000,
+				Protocol:      "tcp",
+				UseMessageBus: false,
+			},
+			"b": {
+				Host:          "localhost",
+				Port:          9001,
+				Protocol:      "udp",
+				UseMessageBus: false,
+			},
+			"c": {
+				Host:          "localhost",
+				Port:          9002,
+				Protocol:      "tcp",
+				UseMessageBus: true,
+			},
+		},
+	}
+
+	var clone ConfigurationMockStruct
+	err := DeepCopy(orig, &clone)
+	require.NoError(t, err)
+
+	// sanity check
+	assert.Equal(t, orig, clone)
+
+	// make sure that changes to the clone do not affect the original
+	clone.Writable.LogLevel = "DEBUG"
+	delete(clone.Clients, "b")
+	assert.NotEqual(t, orig, clone)
+
+}


### PR DESCRIPTION
fixes #524

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [n/a?] I have opened a PR for the related docs change (if not, why?)
 N/A due to no functionality change

## Testing Instructions
<!-- How can the reviewers test your change? -->

- Run EdgeX in non-secure mode
- Run a service with a secret callback code
- Change an InsecureSecret
- Verify that the callback was triggered

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->