### PR TITLE
fix: incorrect call to log.Debug, move WildcardName constant

### DIFF
--- a/bootstrap/handlers/auth_middleware.go
+++ b/bootstrap/handlers/auth_middleware.go
@@ -61,7 +61,7 @@ func VaultAuthenticationHandlerFunc(secretProvider interfaces.SecretProviderExt,
 					http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 					return
 				}
-				lc.Debug("Request to '%s' authorized", r.URL.Path)
+				lc.Debugf("Request to '%s' authorized", r.URL.Path)
 				inner(w, r)
 				return
 			}

--- a/bootstrap/secret/helper.go
+++ b/bootstrap/secret/helper.go
@@ -20,6 +20,8 @@ const (
 	EnvSecretStore = "EDGEX_SECURITY_SECRET_STORE"
 	UsernameKey    = "username"
 	PasswordKey    = "password"
+	// WildcardName is a special secret name that can be used to register a secret callback for any secret.
+	WildcardName = "*"
 )
 
 // IsSecurityEnabled determines if security has been enabled.

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -43,8 +43,6 @@ const (
 	AccessTokenAuthError = "HTTP response with status code 403"
 	//nolint: gosec
 	SecretsAuthError = "Received a '403' response"
-	// WildcardName is a special secret name that can be used to register a secret callback for any secret.
-	WildcardName = "*"
 )
 
 // SecureProvider implements the SecretProvider interface


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [N/A] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [N/A] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->

- I moved the constant out of `secure.go` as that file is specific for the vault/secure implementation. It remains in the same package `secret`.

- Invalid log spotted while debugging (note the `%s` on the last line):
![image](https://user-images.githubusercontent.com/48735240/235758455-17bb3032-d8e1-4de3-b6c5-863974b6d105.png)
