### PR TITLE
feat: add secret token and get secret metrics

### DIFF
--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -20,12 +20,14 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/edgexfoundry/go-mod-secrets/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-secrets/v3/secrets"
+	gometrics "github.com/rcrowley/go-metrics"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
@@ -43,6 +45,8 @@ const (
 	secretsStoredMetricName           = "SecuritySecretsStored"
 	securityConsulTokensRequestedName = "SecurityConsulTokensRequested"
 	securityConsulTokenDurationName   = "SecurityConsulTokenDuration"
+	securitySecretTokenDurationName   = "SecuritySecretTokenDuration"
+	securityGetSecretDurationName     = "SecurityGetSecretDuration"
 )
 
 // NewSecretProvider creates a new fully initialized the Secret Provider.
@@ -85,9 +89,11 @@ func NewSecretProvider(
 					secretStoreConfig.RuntimeTokenProvider)
 			}
 
-			secretConfig, err = getSecretConfig(secretStoreConfig, tokenLoader, runtimeTokenLoader, serviceKey, lc)
+			securitySecretTokenDuration := gometrics.NewTimer()
+			secretConfig, err = getSecretConfig(secretStoreConfig, tokenLoader, runtimeTokenLoader, serviceKey, lc, securitySecretTokenDuration)
 			if err == nil {
 				secureProvider := NewSecureProvider(ctx, secretStoreConfig, lc, tokenLoader, runtimeTokenLoader, serviceKey)
+				secureProvider.securitySecretTokenDuration = securitySecretTokenDuration
 				var secretClient secrets.SecretClient
 
 				lc.Info("Attempting to create secret client")
@@ -171,7 +177,8 @@ func getSecretConfig(secretStoreInfo *config.SecretStoreInfo,
 	tokenLoader authtokenloader.AuthTokenLoader,
 	runtimeTokenLoader runtimetokenprovider.RuntimeTokenProvider,
 	serviceKey string,
-	lc logger.LoggingClient) (types.SecretConfig, error) {
+	lc logger.LoggingClient,
+	securitySecretTokenDuration gometrics.Timer) (types.SecretConfig, error) {
 	secretConfig := types.SecretConfig{
 		Type:                 secretStoreInfo.Type, // Type of SecretStore implementation, i.e. Vault
 		Host:                 secretStoreInfo.Host,
@@ -200,7 +207,9 @@ func getSecretConfig(secretStoreInfo *config.SecretStoreInfo,
 	if secretConfig.RuntimeTokenProvider.Enabled {
 		lc.Info("runtime token provider enabled")
 		// call spiffe token provider to get token on the fly
+		started := time.Now()
 		token, err = runtimeTokenLoader.GetRawToken(serviceKey)
+		securitySecretTokenDuration.UpdateSince(started)
 	} else {
 		lc.Info("load token from file")
 		// else obtain the token from TokenFile

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -65,6 +65,8 @@ type SecureProvider struct {
 	securitySecretsStored         gometrics.Counter
 	securityConsulTokensRequested gometrics.Counter
 	securityConsulTokenDuration   gometrics.Timer
+	securitySecretTokenDuration   gometrics.Timer
+	securityGetSecretDuration     gometrics.Timer
 }
 
 // NewSecureProvider creates & initializes Provider instance for secure secrets.
@@ -86,6 +88,8 @@ func NewSecureProvider(ctx context.Context, secretStoreInfo *config.SecretStoreI
 		securitySecretsStored:         gometrics.NewCounter(),
 		securityConsulTokensRequested: gometrics.NewCounter(),
 		securityConsulTokenDuration:   gometrics.NewTimer(),
+		securitySecretTokenDuration:   gometrics.NewTimer(),
+		securityGetSecretDuration:     gometrics.NewTimer(),
 	}
 	return provider
 }
@@ -101,6 +105,8 @@ func (p *SecureProvider) SetClient(client secrets.SecretClient) {
 // specified secretName will be returned.
 func (p *SecureProvider) GetSecret(secretName string, keys ...string) (map[string]string, error) {
 	p.securitySecretsRequested.Inc(1)
+	started := time.Now()
+	defer p.securityGetSecretDuration.UpdateSince(started)
 
 	if cachedSecrets := p.getSecretsCache(secretName, keys...); cachedSecrets != nil {
 		return cachedSecrets, nil
@@ -459,6 +465,8 @@ func (p *SecureProvider) GetMetricsToRegister() map[string]interface{} {
 		secretsStoredMetricName:           p.securitySecretsStored,
 		securityConsulTokensRequestedName: p.securityConsulTokensRequested,
 		securityConsulTokenDurationName:   p.securityConsulTokenDuration,
+		securitySecretTokenDurationName:   p.securitySecretTokenDuration,
+		securityGetSecretDurationName:     p.securityGetSecretDuration,
 	}
 }
 

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -53,20 +53,20 @@ type SecureProvider struct {
 	lc           logger.LoggingClient
 	loader       authtokenloader.AuthTokenLoader
 	// runtimeTokenProvider is for delayed start services
-	runtimeTokenProvider          runtimetokenprovider.RuntimeTokenProvider
-	serviceKey                    string
-	secretStoreInfo               config.SecretStoreInfo
-	secretsCache                  map[string]map[string]string // secret's secretName, key, value
-	cacheMutex                    *sync.RWMutex
-	lastUpdated                   time.Time
-	ctx                           context.Context
-	registeredSecretCallbacks     map[string]func(secretName string)
-	securitySecretsRequested      gometrics.Counter
-	securitySecretsStored         gometrics.Counter
-	securityConsulTokensRequested gometrics.Counter
-	securityConsulTokenDuration   gometrics.Timer
-	securitySecretTokenDuration   gometrics.Timer
-	securityGetSecretDuration     gometrics.Timer
+	runtimeTokenProvider               runtimetokenprovider.RuntimeTokenProvider
+	serviceKey                         string
+	secretStoreInfo                    config.SecretStoreInfo
+	secretsCache                       map[string]map[string]string // secret's secretName, key, value
+	cacheMutex                         *sync.RWMutex
+	lastUpdated                        time.Time
+	ctx                                context.Context
+	registeredSecretCallbacks          map[string]func(secretName string)
+	securitySecretsRequested           gometrics.Counter
+	securitySecretsStored              gometrics.Counter
+	securityConsulTokensRequested      gometrics.Counter
+	securityConsulTokenDuration        gometrics.Timer
+	securityRuntimeSecretTokenDuration gometrics.Timer
+	securityGetSecretDuration          gometrics.Timer
 }
 
 // NewSecureProvider creates & initializes Provider instance for secure secrets.
@@ -74,22 +74,22 @@ func NewSecureProvider(ctx context.Context, secretStoreInfo *config.SecretStoreI
 	loader authtokenloader.AuthTokenLoader, runtimeTokenLoader runtimetokenprovider.RuntimeTokenProvider,
 	serviceKey string) *SecureProvider {
 	provider := &SecureProvider{
-		lc:                            lc,
-		loader:                        loader,
-		runtimeTokenProvider:          runtimeTokenLoader,
-		serviceKey:                    serviceKey,
-		secretStoreInfo:               *secretStoreInfo,
-		secretsCache:                  make(map[string]map[string]string),
-		cacheMutex:                    &sync.RWMutex{},
-		lastUpdated:                   time.Now(),
-		ctx:                           ctx,
-		registeredSecretCallbacks:     make(map[string]func(secretName string)),
-		securitySecretsRequested:      gometrics.NewCounter(),
-		securitySecretsStored:         gometrics.NewCounter(),
-		securityConsulTokensRequested: gometrics.NewCounter(),
-		securityConsulTokenDuration:   gometrics.NewTimer(),
-		securitySecretTokenDuration:   gometrics.NewTimer(),
-		securityGetSecretDuration:     gometrics.NewTimer(),
+		lc:                                 lc,
+		loader:                             loader,
+		runtimeTokenProvider:               runtimeTokenLoader,
+		serviceKey:                         serviceKey,
+		secretStoreInfo:                    *secretStoreInfo,
+		secretsCache:                       make(map[string]map[string]string),
+		cacheMutex:                         &sync.RWMutex{},
+		lastUpdated:                        time.Now(),
+		ctx:                                ctx,
+		registeredSecretCallbacks:          make(map[string]func(secretName string)),
+		securitySecretsRequested:           gometrics.NewCounter(),
+		securitySecretsStored:              gometrics.NewCounter(),
+		securityConsulTokensRequested:      gometrics.NewCounter(),
+		securityConsulTokenDuration:        gometrics.NewTimer(),
+		securityRuntimeSecretTokenDuration: gometrics.NewTimer(),
+		securityGetSecretDuration:          gometrics.NewTimer(),
 	}
 	return provider
 }
@@ -461,12 +461,12 @@ func (p *SecureProvider) DeregisterSecretUpdatedCallback(secretName string) {
 // GetMetricsToRegister returns all metric objects that needs to be registered.
 func (p *SecureProvider) GetMetricsToRegister() map[string]interface{} {
 	return map[string]interface{}{
-		secretsRequestedMetricName:        p.securitySecretsRequested,
-		secretsStoredMetricName:           p.securitySecretsStored,
-		securityConsulTokensRequestedName: p.securityConsulTokensRequested,
-		securityConsulTokenDurationName:   p.securityConsulTokenDuration,
-		securitySecretTokenDurationName:   p.securitySecretTokenDuration,
-		securityGetSecretDurationName:     p.securityGetSecretDuration,
+		secretsRequestedMetricName:             p.securitySecretsRequested,
+		secretsStoredMetricName:                p.securitySecretsStored,
+		securityConsulTokensRequestedName:      p.securityConsulTokensRequested,
+		securityConsulTokenDurationName:        p.securityConsulTokenDuration,
+		securityRuntimeSecretTokenDurationName: p.securityRuntimeSecretTokenDuration,
+		securityGetSecretDurationName:          p.securityGetSecretDuration,
 	}
 }
 


### PR DESCRIPTION
Closes: #374

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

Run with security on 

1. test with [edgex-go](https://github.com/edgexfoundry/edgex-go/pull/4556) 
2. run `make clean_docker_base docker_base docker`
3. go to edgex-compose/compose-builder
4. `make run dev delayed-start mqtt-bus`
5. `cat /tmp/edgex/secrets/core-data/secrets-token.json` and copy the client_token
6. `export VAULT_TOKEN=insert_client_token`
7. `docker exec -ti -e VAULT_TOKEN=$VAULT_TOKEN edgex-vault vault kv get secret/edgex/core-data/message-bus` and copy the username and password
8. `docker exec -it edgex-mqtt-broker mosquitto_sub -t 'edgex/telemetry/support-scheduler/#' -u username -P password`
9. Look for `SecurityRuntimeSecretTokenDuration` and `SecurityGetSecretDuration`
10. Validate the times against the logs (`docker logs edgex-support-scheduler`)

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->