### PR TITLE
feat: support /api/v3/secret endpoint in non-secure mode

### DIFF
--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -394,3 +394,55 @@ func TestGetConfigFileLocation(t *testing.T) {
 	actual := GetConfigFileLocation(lc, flags)
 	assert.Equal(t, expected, actual)
 }
+
+func TestGetInsecureSecretNameFullPath(t *testing.T) {
+	tests := []struct {
+		secretName string
+		expected   string
+	}{
+		{
+			secretName: "credentials001",
+			expected:   writableKey + "/" + insecureSecretsKey + "/credentials001/" + secretNameKey,
+		},
+		{
+			secretName: "my-secret",
+			expected:   writableKey + "/" + insecureSecretsKey + "/my-secret/" + secretNameKey,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.secretName, func(t *testing.T) {
+			actual := GetInsecureSecretNameFullPath(test.secretName)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestGetInsecureSecretDataFullPath(t *testing.T) {
+	tests := []struct {
+		secretName string
+		key        string
+		expected   string
+	}{
+		{
+			secretName: "credentials001",
+			key:        "username",
+			expected:   writableKey + "/" + insecureSecretsKey + "/credentials001/" + secretDataKey + "/username",
+		},
+		{
+			secretName: "credentials001",
+			key:        "password",
+			expected:   writableKey + "/" + insecureSecretsKey + "/credentials001/" + secretDataKey + "/password",
+		},
+		{
+			secretName: "my-secret",
+			key:        "password",
+			expected:   writableKey + "/" + insecureSecretsKey + "/my-secret/" + secretDataKey + "/password",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.secretName+"_"+test.key, func(t *testing.T) {
+			actual := GetInsecureSecretDataFullPath(test.secretName, test.key)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -16,6 +16,7 @@ package secret
 
 import (
 	"fmt"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
@@ -26,12 +27,6 @@ import (
 	gometrics "github.com/rcrowley/go-metrics"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
-)
-
-const (
-	// todo: should these be in `common` package?
-	writableKey        = "Writable"
-	insecureSecretsKey = writableKey + "/InsecureSecrets"
 )
 
 // InsecureProvider implements the SecretProvider interface for insecure secrets
@@ -121,15 +116,15 @@ func (p *InsecureProvider) StoreSecret(secretName string, secrets map[string]str
 	p.securitySecretsStored.Inc(1)
 
 	// insert the top-level data about the secret name
-	basePath := fmt.Sprintf("%s/%s", insecureSecretsKey, secretName)
-	err := configClient.PutConfigurationValue(basePath+"/SecretName", []byte(secretName))
+	secretPath := fmt.Sprintf("%s/%s", config.InsecureSecretsKey, secretName)
+	err := configClient.PutConfigurationValue(fmt.Sprintf("%s/%s", secretPath, config.SecretNameKey), []byte(secretName))
 	if err != nil {
 		return errors.NewCommonEdgeX(errors.KindCommunicationError, "error setting secretName value in the config provider", err)
 	}
 
 	// insert each secret  key/value pair
 	for key, value := range secrets {
-		err = configClient.PutConfigurationValue(fmt.Sprintf("%s/SecretData/%s", basePath, key), []byte(value))
+		err = configClient.PutConfigurationValue(fmt.Sprintf("%s/%s/%s", secretPath, config.SecretDataKey, key), []byte(value))
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindCommunicationError, "error setting secretData key/value pair in the config provider", err)
 		}

--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -106,7 +106,9 @@ func (p *InsecureProvider) GetSecret(secretName string, keys ...string) (map[str
 	return results, nil
 }
 
-// StoreSecret stores the secrets, but is not supported for Insecure Secrets
+// StoreSecret stores the secrets in the ConfigurationProvider's InsecureSecrets. If no ConfigurationProvider is in use,
+// it will return an error. This does not explicitly call SecretUpdatedAtSecretName because that will get called when
+// the ConfigurationProvider tells the service that the configuration has updated.
 func (p *InsecureProvider) StoreSecret(secretName string, secrets map[string]string) error {
 	configClient := container.ConfigClientFrom(p.dic.Get)
 	if configClient == nil {
@@ -121,7 +123,7 @@ func (p *InsecureProvider) StoreSecret(secretName string, secrets map[string]str
 		return errors.NewCommonEdgeX(errors.KindCommunicationError, "error setting secretName value in the config provider", err)
 	}
 
-	// insert each secret  key/value pair
+	// insert each secret key/value pair
 	for key, value := range secrets {
 		err = configClient.PutConfigurationValue(config.GetInsecureSecretDataFullPath(secretName, key), []byte(value))
 		if err != nil {

--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -116,15 +116,14 @@ func (p *InsecureProvider) StoreSecret(secretName string, secrets map[string]str
 	p.securitySecretsStored.Inc(1)
 
 	// insert the top-level data about the secret name
-	secretPath := fmt.Sprintf("%s/%s", config.InsecureSecretsKey, secretName)
-	err := configClient.PutConfigurationValue(fmt.Sprintf("%s/%s", secretPath, config.SecretNameKey), []byte(secretName))
+	err := configClient.PutConfigurationValue(config.GetInsecureSecretNameFullPath(secretName), []byte(secretName))
 	if err != nil {
 		return errors.NewCommonEdgeX(errors.KindCommunicationError, "error setting secretName value in the config provider", err)
 	}
 
 	// insert each secret  key/value pair
 	for key, value := range secrets {
-		err = configClient.PutConfigurationValue(fmt.Sprintf("%s/%s/%s", secretPath, config.SecretDataKey, key), []byte(value))
+		err = configClient.PutConfigurationValue(config.GetInsecureSecretDataFullPath(secretName, key), []byte(value))
 		if err != nil {
 			return errors.NewCommonEdgeX(errors.KindCommunicationError, "error setting secretData key/value pair in the config provider", err)
 		}

--- a/bootstrap/secret/insecure_test.go
+++ b/bootstrap/secret/insecure_test.go
@@ -139,21 +139,21 @@ func TestInsecureProvider_StoreSecrets(t *testing.T) {
 
 	// make sure the secret name is stored exactly once
 	testMocks.configClient.On("PutConfigurationValue",
-		fmt.Sprintf("%s/%s/%s", config.InsecureSecretsKey, secretName, config.SecretNameKey),
+		config.GetInsecureSecretNameFullPath(secretName),
 		[]uint8(secretName)). // need to use uint8 because byte is just an alias
 		Return(nil).
 		Once()
 
 	// make sure the proper key1/value1 pair is stored exactly once
 	testMocks.configClient.On("PutConfigurationValue",
-		fmt.Sprintf("%s/%s/%s/%s", config.InsecureSecretsKey, secretName, config.SecretDataKey, key1),
+		config.GetInsecureSecretDataFullPath(secretName, key1),
 		[]uint8(value1)). // need to use uint8 because byte is just an alias
 		Return(nil).
 		Once()
 
 	// make sure the proper key2/value2 pair is stored exactly once
 	testMocks.configClient.On("PutConfigurationValue",
-		fmt.Sprintf("%s/%s/%s/%s", config.InsecureSecretsKey, secretName, config.SecretDataKey, key2),
+		config.GetInsecureSecretDataFullPath(secretName, key2),
 		[]uint8(value2)). // need to use uint8 because byte is just an alias
 		Return(nil).
 		Once()

--- a/bootstrap/secret/insecure_test.go
+++ b/bootstrap/secret/insecure_test.go
@@ -16,6 +16,7 @@ package secret
 
 import (
 	"fmt"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/stretchr/testify/mock"
@@ -138,21 +139,21 @@ func TestInsecureProvider_StoreSecrets(t *testing.T) {
 
 	// make sure the secret name is stored exactly once
 	testMocks.configClient.On("PutConfigurationValue",
-		fmt.Sprintf("%s/%s/SecretName", insecureSecretsKey, secretName),
+		fmt.Sprintf("%s/%s/%s", config.InsecureSecretsKey, secretName, config.SecretNameKey),
 		[]uint8(secretName)). // need to use uint8 because byte is just an alias
 		Return(nil).
 		Once()
 
 	// make sure the proper key1/value1 pair is stored exactly once
 	testMocks.configClient.On("PutConfigurationValue",
-		fmt.Sprintf("%s/%s/SecretData/%s", insecureSecretsKey, secretName, key1),
+		fmt.Sprintf("%s/%s/%s/%s", config.InsecureSecretsKey, secretName, config.SecretDataKey, key1),
 		[]uint8(value1)). // need to use uint8 because byte is just an alias
 		Return(nil).
 		Once()
 
 	// make sure the proper key2/value2 pair is stored exactly once
 	testMocks.configClient.On("PutConfigurationValue",
-		fmt.Sprintf("%s/%s/SecretData/%s", insecureSecretsKey, secretName, key2),
+		fmt.Sprintf("%s/%s/%s/%s", config.InsecureSecretsKey, secretName, config.SecretDataKey, key2),
 		[]uint8(value2)). // need to use uint8 because byte is just an alias
 		Return(nil).
 		Once()

--- a/bootstrap/secret/insecure_test.go
+++ b/bootstrap/secret/insecure_test.go
@@ -15,8 +15,14 @@
 package secret
 
 import (
+	"fmt"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/stretchr/testify/mock"
+	"math"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,7 +32,49 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	configurationMocks "github.com/edgexfoundry/go-mod-configuration/v3/configuration/mocks"
 )
+
+// mockObjects holds the various mocks needed for running these tests
+type mockObjects struct {
+	dic          *di.Container
+	lc           logger.LoggingClient
+	configClient *configurationMocks.Client
+}
+
+// newMockObjects creates a full mockObjects with all values
+func newMockObjects() mockObjects {
+	configClient := new(configurationMocks.Client)
+	lc := logger.NewMockClient()
+
+	return mockObjects{
+		dic: di.NewContainer(di.ServiceConstructorMap{
+			container.ConfigClientInterfaceName: func(get di.Get) interface{} {
+				return configClient
+			},
+			container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+				return lc
+			},
+		}),
+		lc:           lc,
+		configClient: configClient,
+	}
+}
+
+// newMockObjectsNoConfigClient creates a new mockObjects, but without the config client
+func newMockObjectsNoConfigClient() mockObjects {
+	lc := logger.NewMockClient()
+
+	return mockObjects{
+		dic: di.NewContainer(di.ServiceConstructorMap{
+			container.LoggingClientInterfaceName: func(get di.Get) interface{} {
+				return lc
+			},
+		}),
+		lc: lc,
+	}
+}
 
 var expectedSecretsKeys = []string{"redisdb", "kongdb"}
 
@@ -63,7 +111,8 @@ func TestInsecureProvider_GetSecrets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewInsecureProvider(tc.Config, logger.MockLogger{})
+			testMocks := newMockObjects()
+			target := NewInsecureProvider(tc.Config, testMocks.lc, testMocks.dic)
 			actual, err := target.GetSecret(tc.SecretName, tc.Keys...)
 			if tc.ExpectError {
 				require.Error(t, err)
@@ -76,14 +125,110 @@ func TestInsecureProvider_GetSecrets(t *testing.T) {
 	}
 }
 
-func TestInsecureProvider_StoreSecrets_Secure(t *testing.T) {
-	target := NewInsecureProvider(nil, nil)
-	err := target.StoreSecret("myPath", map[string]string{"Key": "value"})
+// TestInsecureProvider_StoreSecrets tests that the proper actions are performed when StoreSecrets
+// is called with specific data
+func TestInsecureProvider_StoreSecrets(t *testing.T) {
+	secretName := "test-secret-name"
+	key1 := UsernameKey
+	value1 := "my-username"
+	key2 := PasswordKey
+	value2 := "my-password"
+
+	testMocks := newMockObjects()
+
+	// make sure the secret name is stored exactly once
+	testMocks.configClient.On("PutConfigurationValue",
+		fmt.Sprintf("%s/%s/SecretName", insecureSecretsKey, secretName),
+		[]uint8(secretName)). // need to use uint8 because byte is just an alias
+		Return(nil).
+		Once()
+
+	// make sure the proper key1/value1 pair is stored exactly once
+	testMocks.configClient.On("PutConfigurationValue",
+		fmt.Sprintf("%s/%s/SecretData/%s", insecureSecretsKey, secretName, key1),
+		[]uint8(value1)). // need to use uint8 because byte is just an alias
+		Return(nil).
+		Once()
+
+	// make sure the proper key2/value2 pair is stored exactly once
+	testMocks.configClient.On("PutConfigurationValue",
+		fmt.Sprintf("%s/%s/SecretData/%s", insecureSecretsKey, secretName, key2),
+		[]uint8(value2)). // need to use uint8 because byte is just an alias
+		Return(nil).
+		Once()
+
+	target := NewInsecureProvider(nil, testMocks.lc, testMocks.dic)
+	err := target.StoreSecret(secretName, map[string]string{
+		key1: value1,
+		key2: value2,
+	})
+	require.NoError(t, err)
+
+	testMocks.configClient.AssertExpectations(t)
+}
+
+// TestInsecureProvider_StoreSecrets_NoConfigClient tests what happens when there is no ConfigClient present
+func TestInsecureProvider_StoreSecrets_NoConfigClient(t *testing.T) {
+	testMocks := newMockObjectsNoConfigClient()
+
+	target := NewInsecureProvider(nil, testMocks.lc, testMocks.dic)
+	err := target.StoreSecret("testSecretName", map[string]string{
+		UsernameKey: "user",
+		PasswordKey: "pass",
+	})
+	// expect an error because Config Client is not available
 	require.Error(t, err)
 }
 
+// TestInsecureProvider_StoreSecrets_Error tests what happens when an error is returned at various stages in the
+// StoreSecrets method
+func TestInsecureProvider_StoreSecrets_Error(t *testing.T) {
+	totalCalls := 5
+	// note: internally, put value is called 1 time for secretName and 1 additional time for each key/value pair
+	// failing on first call, means failed to set secretName, and failing on calls 2-5 means failing to store key/values
+	for failAtCall := 1; failAtCall <= totalCalls+1; failAtCall++ {
+		t.Run(strconv.Itoa(failAtCall), func(t *testing.T) {
+			testMocks := newMockObjects()
+			callNumber := 0
+
+			mockCall := testMocks.configClient.On("PutConfigurationValue",
+				mock.AnythingOfType("string"),
+				mock.AnythingOfType("[]uint8")). // need to use uint8 because byte is just an alias
+				// expect to be called at either the failAtCall, or totalCalls if failAtCall is > totalCalls
+				Times(int(math.Min(float64(failAtCall), float64(totalCalls))))
+
+			mockCall.Run(func(args mock.Arguments) {
+				callNumber += 1
+				if callNumber < failAtCall {
+					mockCall.Return(nil)
+				} else {
+					mockCall.Return(fmt.Errorf("returning error on call numbner %d", failAtCall))
+				}
+			})
+
+			target := NewInsecureProvider(nil, testMocks.lc, testMocks.dic)
+			err := target.StoreSecret("testSecretName", map[string]string{
+				UsernameKey: "user",
+				PasswordKey: "pass",
+				"extraKey":  "value",
+				"evenMore":  "less",
+			})
+			testMocks.configClient.AssertExpectations(t)
+
+			if failAtCall < 6 {
+				// expect an error because Config Client returned an error at some point
+				require.Error(t, err)
+			} else {
+				// expect no error because all calls should have succeeded
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestInsecureProvider_SecretsUpdated_SecretsLastUpdated(t *testing.T) {
-	target := NewInsecureProvider(nil, logger.MockLogger{})
+	testMocks := newMockObjects()
+	target := NewInsecureProvider(nil, testMocks.lc, testMocks.dic)
 	previous := target.SecretsLastUpdated()
 	time.Sleep(1 * time.Second)
 	target.SecretsUpdated()
@@ -92,14 +237,16 @@ func TestInsecureProvider_SecretsUpdated_SecretsLastUpdated(t *testing.T) {
 }
 
 func TestInsecureProvider_GetAccessToken(t *testing.T) {
-	target := NewInsecureProvider(nil, logger.MockLogger{})
+	testMocks := newMockObjects()
+	target := NewInsecureProvider(nil, testMocks.lc, testMocks.dic)
 	actualToken, err := target.GetAccessToken(TokenTypeConsul, "my-service-key")
 	require.NoError(t, err)
 	assert.Len(t, actualToken, 0)
 }
 
 func TestInsecureProvider_GetSelfJWT(t *testing.T) {
-	target := NewInsecureProvider(nil, logger.MockLogger{})
+	testMocks := newMockObjects()
+	target := NewInsecureProvider(nil, testMocks.lc, testMocks.dic)
 	actualToken, err := target.GetSelfJWT()
 	require.NoError(t, err)
 	require.Equal(t, "", actualToken)
@@ -107,7 +254,8 @@ func TestInsecureProvider_GetSelfJWT(t *testing.T) {
 
 func TestInsecureProvider_IsJWTValid(t *testing.T) {
 	nullJWT := "eyJhbGciOiJOb25lIiwidHlwIjoiSldUIn0.e30."
-	target := NewInsecureProvider(nil, logger.MockLogger{})
+	testMocks := newMockObjects()
+	target := NewInsecureProvider(nil, testMocks.lc, testMocks.dic)
 	result, err := target.IsJWTValid(nullJWT)
 	require.NoError(t, err)
 	require.Equal(t, true, result)
@@ -147,7 +295,8 @@ func TestInsecureProvider_ListPaths(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewInsecureProvider(tc.Config, logger.MockLogger{})
+			testMocks := newMockObjects()
+			target := NewInsecureProvider(tc.Config, testMocks.lc, testMocks.dic)
 			actual, err := target.ListSecretNames()
 			if tc.ExpectError {
 				require.Error(t, err)
@@ -202,7 +351,8 @@ func TestInsecureProvider_HasSecrets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewInsecureProvider(tc.Config, logger.MockLogger{})
+			testMocks := newMockObjects()
+			target := NewInsecureProvider(tc.Config, testMocks.lc, testMocks.dic)
 			actual, err := target.HasSecret(tc.Path)
 			if tc.ExpectError {
 				require.Error(t, err)
@@ -252,7 +402,8 @@ func TestInsecureProvider_SecretUpdatedAtPath(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			callbackCalled = false
 			wildcardCalled = false
-			target := NewInsecureProvider(tc.Config, logger.NewMockClient())
+			testMocks := newMockObjects()
+			target := NewInsecureProvider(tc.Config, testMocks.lc, testMocks.dic)
 
 			if tc.Callback != nil {
 				target.registeredSecretCallbacks[tc.SecretName] = tc.Callback
@@ -291,7 +442,8 @@ func TestInsecureProvider_RegisterSecretUpdatedCallback(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewInsecureProvider(tc.Config, logger.MockLogger{})
+			testMocks := newMockObjects()
+			target := NewInsecureProvider(tc.Config, testMocks.lc, testMocks.dic)
 			err := target.RegisterSecretUpdatedCallback(tc.SecretName, tc.Callback)
 			assert.NoError(t, err)
 
@@ -325,7 +477,8 @@ func TestInsecureProvider_DeregisterSecretUpdatedCallback(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
-			target := NewInsecureProvider(tc.Config, logger.MockLogger{})
+			testMocks := newMockObjects()
+			target := NewInsecureProvider(tc.Config, testMocks.lc, testMocks.dic)
 			err := target.RegisterSecretUpdatedCallback(tc.SecretName, tc.Callback)
 			assert.NoError(t, err)
 

--- a/bootstrap/secret/secret.go
+++ b/bootstrap/secret/secret.go
@@ -138,7 +138,7 @@ func NewSecretProvider(
 		}
 
 	case false:
-		provider = NewInsecureProvider(configuration, lc)
+		provider = NewInsecureProvider(configuration, lc, dic)
 	}
 
 	dic.Update(di.ServiceConstructorMap{


### PR DESCRIPTION
Implements the StoreSecret function for InsecureProvider. If the ConfigurationClient is in use, it will be used to store the secret, otherwise an error is returned.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
**Run the new unit tests**
```
make test
```

**Try it out yourself**
1. clone latest edgex-compose
2. modify a device service to build using this code
go.mod:
```
replace github.com/edgexfoundry/go-mod-bootstrap/v3 => ../go-mod-bootstrap
```
3. build docker image
```
make docker
```
4. tag image so it is latest:
```
 docker tag edgexfoundry/device-usb-camera:0.0.0-dev nexus3.edgexfoundry.org:10004/device-usb-camera:latest 
```
5. pull latest edgex images
```
cd compose-builder
make pull
```
6. deploy in non-secure mode with `device-usb-camera`
```
make run no-secty ds-usb-camera
```
7. Wait for the service to start up
8. post a secret to to said device service:
```sh
curl --data '{
    "apiVersion":"v3",
    "secretName": "rtspauth",
    "secretData":[
        {
            "key":"username",
            "value":"<pick-a-username>"
        },
        {
            "key":"password",
            "value":"<pick-a-secure-password>"
        }
    ]
}' -X POST http://localhost:59983/api/v3/secret
```
9. expect a 201 Created
```
{"apiVersion":"v3","statusCode":201}
```
10. Verify the data is successfully in consul
http://localhost:8500/ui/dc1/kv/edgex/v3/device-usb-camera/Writable/InsecureSecrets



## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->

Closes #477 