### PR TITLE
feat: Use loadfile that allows reading from local file or uri

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -216,7 +216,7 @@ func (cp *Processor) Process(
 	// Now load the private config from a local file if any of these conditions are true
 	if !useProvider || !cp.providerHasConfig || cp.overwriteConfig {
 		filePath := GetConfigFileLocation(cp.lc, cp.flags)
-		configMap, err := cp.loadConfigYamlFromFile(filePath, defaultTimeout, secretProvider)
+		configMap, err := cp.loadConfigYamlFromFile(filePath, file.DefaultTimeout, secretProvider)
 		if err != nil {
 			return err
 		}
@@ -666,7 +666,7 @@ func GetConfigFileLocation(lc logger.LoggingClient, flags flags.Common) string {
 		lc.Errorf("Could not parse file path: %v", err)
 		return ""
 	}
-	lc.Infof("name %s, parsedurl: %v", configFileName, parsedUrl)
+
 	if parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https" {
 		return configFileName
 	}

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -639,9 +639,6 @@ func CreateProviderClient(
 // loadConfigYamlFromFile attempts to read the specified configuration yaml file
 func (cp *Processor) loadConfigYamlFromFile(yamlFile string) (map[string]any, error) {
 	secretProvider := container.SecretProviderExtFrom(cp.dic.Get)
-	if secretProvider != nil {
-		return nil, fmt.Errorf("failed to get secret provider")
-	}
 
 	cp.lc.Infof("Loading configuration file from %s", yamlFile)
 	contents, err := file.Load(yamlFile, secretProvider, cp.lc)

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -215,10 +215,10 @@ func (cp *Processor) Process(
 
 	// Now load the private config from a local file if any of these conditions are true
 	if !useProvider || !cp.providerHasConfig || cp.overwriteConfig {
-		requestTimeout, err := time.ParseDuration(environment.GetRequestTimeout(cp.lc, cp.flags.RequestTimeout()))
+		requestTimeout, err := time.ParseDuration(environment.GetFileUriTimeout(cp.lc))
 		if err != nil {
-			cp.lc.Debug("Failed to parse Service.RequestTimeout configuration value: %v, using default value", err)
-			requestTimeout = 15 * time.Second
+			cp.lc.Warn("Failed to parse Service.RequestTimeout configuration value: %v, using default value to load config from URI", err)
+			requestTimeout = defaultTimeout
 		}
 
 		filePath := GetConfigFileLocation(cp.lc, cp.flags)

--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -215,8 +215,14 @@ func (cp *Processor) Process(
 
 	// Now load the private config from a local file if any of these conditions are true
 	if !useProvider || !cp.providerHasConfig || cp.overwriteConfig {
+		requestTimeout, err := time.ParseDuration(environment.GetRequestTimeout(cp.lc, cp.flags.RequestTimeout()))
+		if err != nil {
+			cp.lc.Debug("Failed to parse Service.RequestTimeout configuration value: %v, using default value", err)
+			requestTimeout = 15 * time.Second
+		}
+
 		filePath := GetConfigFileLocation(cp.lc, cp.flags)
-		configMap, err := cp.loadConfigYamlFromFile(filePath, file.DefaultTimeout, secretProvider)
+		configMap, err := cp.loadConfigYamlFromFile(filePath, requestTimeout, secretProvider)
 		if err != nil {
 			return err
 		}

--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -394,6 +394,20 @@ func TestGetConfigFileLocation(t *testing.T) {
 			expected: filepath.Join("myRes", "myProfile", "myFile.yaml"),
 		},
 		{
+			name:     "valid - file absolute path",
+			dir:      "/myRes",
+			profile:  "myProfile",
+			path:     "myFile.yaml",
+			expected: "/myRes/myProfile/myFile.yaml",
+		},
+		{
+			name:     "valid - file relative path",
+			dir:      "../../myRes",
+			profile:  "myProfile",
+			path:     "myFile.yaml",
+			expected: "../../myRes/myProfile/myFile.yaml",
+		},
+		{
 			name:     "valid - url",
 			dir:      "",
 			profile:  "",

--- a/bootstrap/config/config_test.go
+++ b/bootstrap/config/config_test.go
@@ -299,7 +299,7 @@ func TestLoadCommonConfigFromFile(t *testing.T) {
 			proc := NewProcessor(f, env, timer, ctx, &wg, nil, dic)
 
 			// call load common config
-			err := proc.loadCommonConfigFromFile(tc.config, tc.serviceConfig, tc.serviceType, nil)
+			err := proc.loadCommonConfigFromFile(tc.config, tc.serviceConfig, tc.serviceType)
 			// make assertions
 			require.NotNil(t, cancel)
 			if tc.expectedErr == "" {

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -462,7 +462,7 @@ func logEnvironmentOverride(lc logger.LoggingClient, name string, key string, va
 }
 
 // GetURIRequestTimeout gets the configuration request timeout value from an environment variable (if it exists)
-// or uses passed in value.
+// or uses default value.
 func GetURIRequestTimeout(lc logger.LoggingClient) time.Duration {
 	envValue := os.Getenv(envKeyFileURITimeout)
 	if len(envValue) <= 0 {

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -461,7 +461,7 @@ func logEnvironmentOverride(lc logger.LoggingClient, name string, key string, va
 	lc.Infof("Variables override of '%s' by environment variable: %s=%s", name, key, valueStr)
 }
 
-// GetURIRequestTimeout gets the configuration request timeout value from a Variables variable value (if it exists)
+// GetURIRequestTimeout gets the configuration request timeout value from an environment variable (if it exists)
 // or uses passed in value.
 func GetURIRequestTimeout(lc logger.LoggingClient) time.Duration {
 	envValue := os.Getenv(envKeyFileURITimeout)

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -44,7 +44,7 @@ const (
 	envKeyConfigDir       = "EDGEX_CONFIG_DIR"
 	envKeyProfile         = "EDGEX_PROFILE"
 	envKeyConfigFile      = "EDGEX_CONFIG_FILE"
-	envKeyRequestTimeout  = "EDGEX_SERVICE_REQUESTTIMEOUT"
+	envKeyRequestTimeout  = "EGDEX_FILE_URI_TIMEOUT"
 
 	noConfigProviderValue = "none"
 
@@ -458,13 +458,13 @@ func logEnvironmentOverride(lc logger.LoggingClient, name string, key string, va
 	lc.Infof("Variables override of '%s' by environment variable: %s=%s", name, key, valueStr)
 }
 
-// GetRequestTimeout gets the configuration request timeout value from a Variables variable value (if it exists)
+// GetFileUriTimeout gets the configuration request timeout value from a variable value (if it exists)
 // or uses passed in value.
-func GetRequestTimeout(lc logger.LoggingClient, requestTimeout string) string {
+func GetFileUriTimeout(lc logger.LoggingClient) string {
+	requestTimeout := "15"
 	envValue := os.Getenv(envKeyRequestTimeout)
 	if len(envValue) > 0 {
 		requestTimeout = envValue
-		logEnvironmentOverride(lc, "-rt/--requestTimeout", envKeyRequestTimeout, envValue)
 	}
 
 	return requestTimeout

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -44,6 +44,7 @@ const (
 	envKeyConfigDir       = "EDGEX_CONFIG_DIR"
 	envKeyProfile         = "EDGEX_PROFILE"
 	envKeyConfigFile      = "EDGEX_CONFIG_FILE"
+	envKeyRequestTimeout  = "EDGEX_SERVICE_REQUESTTIMEOUT"
 
 	noConfigProviderValue = "none"
 
@@ -455,4 +456,16 @@ func logEnvironmentOverride(lc logger.LoggingClient, name string, key string, va
 		valueStr = redactedStr
 	}
 	lc.Infof("Variables override of '%s' by environment variable: %s=%s", name, key, valueStr)
+}
+
+// GetRequestTimeout gets the configuration request timeout value from a Variables variable value (if it exists)
+// or uses passed in value.
+func GetRequestTimeout(lc logger.LoggingClient, requestTimeout string) string {
+	envValue := os.Getenv(envKeyRequestTimeout)
+	if len(envValue) > 0 {
+		requestTimeout = envValue
+		logEnvironmentOverride(lc, "-rt/--requestTimeout", envKeyRequestTimeout, envValue)
+	}
+
+	return requestTimeout
 }

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -586,3 +586,32 @@ func TestOverrideConfigMapValues(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRequestTimeout(t *testing.T) {
+	_, lc := initializeTest()
+
+	testCases := []struct {
+		TestName        string
+		EnvTimeout      string
+		PassedInTimeout string
+		ExpectedTimeout string
+	}{
+		{"With Env Var", envKeyRequestTimeout, "15", "14"},
+		{"With No Env Var", "", "15", "15"},
+		{"With No Env Var and no passed in", "", "", ""},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.TestName, func(t *testing.T) {
+			os.Clearenv()
+
+			if len(test.EnvTimeout) > 0 {
+				err := os.Setenv(test.EnvTimeout, test.ExpectedTimeout)
+				require.NoError(t, err)
+			}
+
+			actual := GetRequestTimeout(lc, test.PassedInTimeout)
+			assert.Equal(t, test.ExpectedTimeout, actual)
+		})
+	}
+}

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -594,11 +594,10 @@ func TestGetRequestTimeout(t *testing.T) {
 	testCases := []struct {
 		TestName        string
 		EnvTimeout      string
-		PassedInTimeout string
 		ExpectedTimeout time.Duration
 	}{
-		{"With Env Var", envKeyFileURITimeout, "15", 15 * time.Second},
-		{"With No Env Var", "", "15", 15 * time.Second},
+		{"With Env Var", envKeyFileURITimeout, 15 * time.Second},
+		{"With No Env Var", "", 15 * time.Second},
 	}
 
 	for _, test := range testCases {
@@ -606,7 +605,7 @@ func TestGetRequestTimeout(t *testing.T) {
 			os.Clearenv()
 
 			if len(test.EnvTimeout) > 0 {
-				err := os.Setenv(test.EnvTimeout, test.PassedInTimeout)
+				err := os.Setenv(test.EnvTimeout, test.ExpectedTimeout.String())
 				require.NoError(t, err)
 			}
 

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	loggerMocks "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger/mocks"
 	"github.com/stretchr/testify/mock"
@@ -587,16 +588,17 @@ func TestOverrideConfigMapValues(t *testing.T) {
 	}
 }
 
-func TestGetFileUriTimeout(t *testing.T) {
+func TestGetRequestTimeout(t *testing.T) {
 	_, lc := initializeTest()
 
 	testCases := []struct {
 		TestName        string
 		EnvTimeout      string
-		ExpectedTimeout string
+		PassedInTimeout string
+		ExpectedTimeout time.Duration
 	}{
-		{"With Env Var", envKeyRequestTimeout, "14"},
-		{"With No Env Var", "", "15"},
+		{"With Env Var", envKeyFileURITimeout, "15", 15 * time.Second},
+		{"With No Env Var", "", "15", 15 * time.Second},
 	}
 
 	for _, test := range testCases {
@@ -604,11 +606,11 @@ func TestGetFileUriTimeout(t *testing.T) {
 			os.Clearenv()
 
 			if len(test.EnvTimeout) > 0 {
-				err := os.Setenv(test.EnvTimeout, test.ExpectedTimeout)
+				err := os.Setenv(test.EnvTimeout, test.PassedInTimeout)
 				require.NoError(t, err)
 			}
 
-			actual := GetFileUriTimeout(lc)
+			actual := GetURIRequestTimeout(lc)
 			assert.Equal(t, test.ExpectedTimeout, actual)
 		})
 	}

--- a/bootstrap/environment/variables_test.go
+++ b/bootstrap/environment/variables_test.go
@@ -587,18 +587,16 @@ func TestOverrideConfigMapValues(t *testing.T) {
 	}
 }
 
-func TestGetRequestTimeout(t *testing.T) {
+func TestGetFileUriTimeout(t *testing.T) {
 	_, lc := initializeTest()
 
 	testCases := []struct {
 		TestName        string
 		EnvTimeout      string
-		PassedInTimeout string
 		ExpectedTimeout string
 	}{
-		{"With Env Var", envKeyRequestTimeout, "15", "14"},
-		{"With No Env Var", "", "15", "15"},
-		{"With No Env Var and no passed in", "", "", ""},
+		{"With Env Var", envKeyRequestTimeout, "14"},
+		{"With No Env Var", "", "15"},
 	}
 
 	for _, test := range testCases {
@@ -610,7 +608,7 @@ func TestGetRequestTimeout(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			actual := GetRequestTimeout(lc, test.PassedInTimeout)
+			actual := GetFileUriTimeout(lc)
 			assert.Equal(t, test.ExpectedTimeout, actual)
 		})
 	}

--- a/bootstrap/file/file.go
+++ b/bootstrap/file/file.go
@@ -11,6 +11,8 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
 )
 
+const DefaultTimeout = 15 * time.Second
+
 func Load(path string, timeout time.Duration, provider interfaces.SecretProvider) ([]byte, error) {
 	var fileBytes []byte
 	var err error

--- a/bootstrap/file/file.go
+++ b/bootstrap/file/file.go
@@ -6,14 +6,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"time"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/environment"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 )
 
-const DefaultTimeout = 15 * time.Second
-
-func Load(path string, timeout time.Duration, provider interfaces.SecretProvider) ([]byte, error) {
+func Load(path string, provider interfaces.SecretProvider, lc logger.LoggingClient) ([]byte, error) {
 	var fileBytes []byte
 	var err error
 
@@ -24,7 +23,7 @@ func Load(path string, timeout time.Duration, provider interfaces.SecretProvider
 
 	if parsedUrl.Scheme == "http" || parsedUrl.Scheme == "https" {
 		client := &http.Client{
-			Timeout: timeout,
+			Timeout: environment.GetURIRequestTimeout(lc),
 		}
 		req, err := http.NewRequest("GET", path, nil)
 		if err != nil {

--- a/bootstrap/file/file_test.go
+++ b/bootstrap/file/file_test.go
@@ -25,11 +25,13 @@ func TestLoadFile(t *testing.T) {
 		{"Valid - load from JSON file", path.Join(".", "testdata", "configuration.json"), 142, "", nil},
 		{"Valid - load from HTTP", "http://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/testdata/configuration.yaml", 4533, "", nil},
 		{"Valid - load from HTTPS", "https://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/testdata/configuration.yaml", 4533, "", nil},
+		{"Valid - load from HTTPS with secret", "https://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/testdata/configuration.yaml?edgexSecretName=mySecretName", 4533, "", map[string]string{"type": "httpheader", "headername": "Authorization", "headercontents": "Basic 1234567890"}},
 		{"Invalid - File not found", "bogus", 0, "Could not read file", nil},
+		{"Invalid - parse uri fail", "{test:\"test\"}", 0, "Could not parse file path", nil},
 		{"Invalid - load from invalid HTTP", "http://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/configuration.yaml", 1, "Invalid status code", nil},
 		{"Invalid - load from invalid HTTPS", "https://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/configuration.yaml", 1, "Invalid status code", nil},
-		{"Valid - load from HTTPS with secret", "https://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/testdata/configuration.yaml?edgexSecretName=mySecretName", 4533, "", map[string]string{"type": "httpheader", "headername": "Authorization", "headercontents": "Basic 1234567890"}},
 		{"Invalid - load from HTTPS with invalid secret", "https://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/testdata/configuration.yaml?edgexSecretName=mySecretName", 4533, "Secret type is not httpheader", map[string]string{"type": "invalidheader", "headername": "Authorization", "headercontents": "Basic 1234567890"}},
+		{"Invalid - load from HTTPS with empty secret", "https://raw.githubusercontent.com/edgexfoundry/go-mod-bootstrap/main/bootstrap/config/testdata/configuration.yaml?edgexSecretName=mySecretName", 0, "Secret headername and headercontents can not be empty", map[string]string{"type": "httpheader", "headername": "", "headercontents": ""}},
 	}
 
 	for _, tc := range tests {

--- a/bootstrap/file/file_test.go
+++ b/bootstrap/file/file_test.go
@@ -3,7 +3,6 @@ package file
 import (
 	"path"
 	"testing"
-	"time"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
@@ -47,7 +46,7 @@ func TestLoadFile(t *testing.T) {
 		})
 
 		t.Run(tc.Name, func(t *testing.T) {
-			bytesOut, err := Load(tc.Path, 10*time.Second, mockSecretProvider)
+			bytesOut, err := Load(tc.Path, DefaultTimeout, mockSecretProvider)
 			if tc.ExpectedErr != "" {
 				assert.Contains(t, err.Error(), tc.ExpectedErr)
 				return

--- a/bootstrap/file/file_test.go
+++ b/bootstrap/file/file_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces/mocks"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
 	"github.com/stretchr/testify/assert"
 )
 
 var dic *di.Container
 
 func TestLoadFile(t *testing.T) {
+	lc := logger.NewMockClient()
 	tests := []struct {
 		Name               string
 		Path               string
@@ -46,7 +48,7 @@ func TestLoadFile(t *testing.T) {
 		})
 
 		t.Run(tc.Name, func(t *testing.T) {
-			bytesOut, err := Load(tc.Path, DefaultTimeout, mockSecretProvider)
+			bytesOut, err := Load(tc.Path, mockSecretProvider, lc)
 			if tc.ExpectedErr != "" {
 				assert.Contains(t, err.Error(), tc.ExpectedErr)
 				return

--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -24,6 +24,7 @@ import (
 const (
 	DefaultConfigProvider = "consul.http://localhost:8500"
 	DefaultConfigFile     = "configuration.yaml"
+	DefaultRequestTimeout = "15"
 )
 
 // Common is an interface that defines AP for the common command-line flags used by most EdgeX services
@@ -35,6 +36,7 @@ type Common interface {
 	Profile() string
 	ConfigDirectory() string
 	ConfigFileName() string
+	RequestTimeout() string
 	CommonConfig() string
 	Parse([]string)
 	Help()
@@ -52,6 +54,7 @@ type Default struct {
 	profile           string
 	configDir         string
 	configFileName    string
+	requestTimeout    string
 }
 
 // NewWithUsage returns a Default struct.
@@ -93,6 +96,8 @@ func (d *Default) Parse(arguments []string) {
 	d.FlagSet.BoolVar(&d.overwriteConfig, "o", false, "")
 	d.FlagSet.StringVar(&d.configFileName, "cf", DefaultConfigFile, "")
 	d.FlagSet.StringVar(&d.configFileName, "configFile", DefaultConfigFile, "")
+	d.FlagSet.StringVar(&d.requestTimeout, "rt", DefaultRequestTimeout, "")
+	d.FlagSet.StringVar(&d.requestTimeout, "requestTimeout", DefaultRequestTimeout, "")
 	d.FlagSet.StringVar(&d.profile, "profile", "", "")
 	d.FlagSet.StringVar(&d.profile, "p", "", ".")
 	d.FlagSet.StringVar(&d.configDir, "configDir", "", "")
@@ -151,6 +156,11 @@ func (d *Default) CommonConfig() string {
 	return d.commonConfig
 }
 
+// CommonConfig returns the location for the common configuration
+func (d *Default) RequestTimeout() string {
+	return d.requestTimeout
+}
+
 // Help displays the usage help message and exit.
 func (d *Default) Help() {
 	d.helpCallback()
@@ -169,6 +179,7 @@ func (d *Default) helpCallback() {
 			"                                    *** Use with cation *** Use will clobber existing settings in provider,\n"+
 			"                                    problematic if those settings were edited by hand intentionally\n"+
 			"    -cf, --configFile <name>        Indicates name of the local configuration file. Defaults to configuration.toml\n"+
+			"    -rt, --requestTimeout <seconds> Set the uri file load request timeout\n"+
 			"    -p, --profile <name>            Indicate configuration profile other than default\n"+
 			"    -cd, --configDir                Specify local configuration directory\n"+
 			"    -r, --registry                  Indicates service should use Registry.\n"+

--- a/bootstrap/flags/flags.go
+++ b/bootstrap/flags/flags.go
@@ -24,7 +24,6 @@ import (
 const (
 	DefaultConfigProvider = "consul.http://localhost:8500"
 	DefaultConfigFile     = "configuration.yaml"
-	DefaultRequestTimeout = "15"
 )
 
 // Common is an interface that defines AP for the common command-line flags used by most EdgeX services
@@ -36,7 +35,6 @@ type Common interface {
 	Profile() string
 	ConfigDirectory() string
 	ConfigFileName() string
-	RequestTimeout() string
 	CommonConfig() string
 	Parse([]string)
 	Help()
@@ -54,7 +52,6 @@ type Default struct {
 	profile           string
 	configDir         string
 	configFileName    string
-	requestTimeout    string
 }
 
 // NewWithUsage returns a Default struct.
@@ -96,8 +93,6 @@ func (d *Default) Parse(arguments []string) {
 	d.FlagSet.BoolVar(&d.overwriteConfig, "o", false, "")
 	d.FlagSet.StringVar(&d.configFileName, "cf", DefaultConfigFile, "")
 	d.FlagSet.StringVar(&d.configFileName, "configFile", DefaultConfigFile, "")
-	d.FlagSet.StringVar(&d.requestTimeout, "rt", DefaultRequestTimeout, "")
-	d.FlagSet.StringVar(&d.requestTimeout, "requestTimeout", DefaultRequestTimeout, "")
 	d.FlagSet.StringVar(&d.profile, "profile", "", "")
 	d.FlagSet.StringVar(&d.profile, "p", "", ".")
 	d.FlagSet.StringVar(&d.configDir, "configDir", "", "")
@@ -156,11 +151,6 @@ func (d *Default) CommonConfig() string {
 	return d.commonConfig
 }
 
-// CommonConfig returns the location for the common configuration
-func (d *Default) RequestTimeout() string {
-	return d.requestTimeout
-}
-
 // Help displays the usage help message and exit.
 func (d *Default) Help() {
 	d.helpCallback()
@@ -179,7 +169,6 @@ func (d *Default) helpCallback() {
 			"                                    *** Use with cation *** Use will clobber existing settings in provider,\n"+
 			"                                    problematic if those settings were edited by hand intentionally\n"+
 			"    -cf, --configFile <name>        Indicates name of the local configuration file. Defaults to configuration.toml\n"+
-			"    -rt, --requestTimeout <seconds> Set the uri file load request timeout\n"+
 			"    -p, --profile <name>            Indicate configuration profile other than default\n"+
 			"    -cd, --configDir                Specify local configuration directory\n"+
 			"    -r, --registry                  Indicates service should use Registry.\n"+


### PR DESCRIPTION
close #553

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- add EDGEX_CONFIG_FILE=<url path to valid config.yaml file> to any service
- start edgex in secure or no-secure mode
- Modified service should get config from the remote location instead of the local copy.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->