### PR TITLE
feat: add better error handlings when common config is missing

### DIFF
--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -110,6 +110,11 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 						return false
 					}
 
+					if len(config.GetBootstrap().Service.RequestTimeout) == 0 {
+						lc.Error("Service.RequestTimeout found empty in bootstrap config, missing common config? Use -cp or -cc flags for common config")
+						return false
+					}
+
 					// TODO: Move following outside loop when multiple messaging based clients exist
 					timeout, err := time.ParseDuration(config.GetBootstrap().Service.RequestTimeout)
 					if err != nil {

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -111,7 +111,7 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 					}
 
 					if len(config.GetBootstrap().Service.RequestTimeout) == 0 {
-						lc.Error("Service.RequestTimeout found empty in bootstrap config, missing common config? Use -cp or -cc flags for common config")
+						lc.Error("Service.RequestTimeout found empty in service's configuration, missing common config? Use -cp or -cc flags for common config")
 						return false
 					}
 

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -89,7 +89,7 @@ func (b *HttpServer) BootstrapHandler(
 
 	if bootstrapConfig.Service.Port == 0 {
 		// should not be 0 as if it were set in local config
-		lc.Error("Service.Port is missing or should not be 0 in local private config")
+		lc.Error("Service.Port is missing from service's configuration or should not be 0 in local private config")
 		return false
 	}
 
@@ -104,7 +104,7 @@ func (b *HttpServer) BootstrapHandler(
 	}
 
 	if len(bootstrapConfig.Service.RequestTimeout) == 0 {
-		lc.Error("Service.RequestTimeout found empty in bootstrap config, missing common config? Use -cp or -cc flags for common config")
+		lc.Error("Service.RequestTimeout found empty in service's configuration, missing common config? Use -cp or -cc flags for common config")
 		return false
 	}
 

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -1,6 +1,7 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
  * Copyright 2021-2022 IOTech Ltd
+ * Copyright 2023 Intel Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -86,6 +87,12 @@ func (b *HttpServer) BootstrapHandler(
 
 	bootstrapConfig := container.ConfigurationFrom(dic.Get).GetBootstrap()
 
+	if bootstrapConfig.Service.Port == 0 {
+		// should not be 0 as if it were set in local config
+		lc.Error("Service.Port is missing or should not be 0 in local private config")
+		return false
+	}
+
 	// this allows env override to explicitly set the value used
 	// for ListenAndServe as needed for different deployments
 	port := strconv.Itoa(bootstrapConfig.Service.Port)
@@ -94,6 +101,11 @@ func (b *HttpServer) BootstrapHandler(
 	// the ServerBindAddr value is not specified
 	if bootstrapConfig.Service.ServerBindAddr == "" {
 		addr = bootstrapConfig.Service.Host + ":" + port
+	}
+
+	if len(bootstrapConfig.Service.RequestTimeout) == 0 {
+		lc.Error("Service.RequestTimeout found empty in bootstrap config, missing common config? Use -cp or -cc flags for common config")
+		return false
 	}
 
 	timeout, err := time.ParseDuration(bootstrapConfig.Service.RequestTimeout)

--- a/bootstrap/handlers/messaging.go
+++ b/bootstrap/handlers/messaging.go
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2022 Intel Corp.
+ * Copyright 2022-2023 Intel Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,8 +41,8 @@ func MessagingBootstrapHandler(ctx context.Context, wg *sync.WaitGroup, startupT
 		return true
 	}
 
-	if len(messageBus.Host) == 0 {
-		lc.Error("MessageBus configuration not set or missing from service's GetBootstrap() implementation")
+	if len(messageBus.Host) == 0 || messageBus.Port == 0 || len(messageBus.Protocol) == 0 || len(messageBus.Type) == 0 {
+		lc.Error("MessageBus configuration is incomplete, missing common config? Use -cp or -cc flags for common config.")
 		return false
 	}
 

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2019 Dell Inc.
- * Copyright 2020 Intel Inc.
+ * Copyright 2020, 2023 Intel Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -41,6 +41,10 @@ func createRegistryClient(
 	dic *di.Container) (registry.Client, error) {
 	bootstrapConfig := serviceConfig.GetBootstrap()
 
+	if *bootstrapConfig.Registry == (config.RegistryInfo{}) {
+		return nil, errors.New("Registry configuration is empty, missing common config? Use -cp or -cc flags for common config.")
+	}
+
 	var err error
 	var accessToken string
 	var getAccessToken registryTypes.GetAccessTokenCallback
@@ -66,6 +70,10 @@ func createRegistryClient(
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if len(bootstrapConfig.Registry.Host) == 0 || bootstrapConfig.Registry.Port == 0 || len(bootstrapConfig.Registry.Type) == 0 {
+		return nil, errors.New("Registry config is incomplete, missing common config? Use -cp or -cc flags for common config.")
 	}
 
 	registryConfig := registryTypes.Config{

--- a/bootstrap/registration/registry.go
+++ b/bootstrap/registration/registry.go
@@ -41,10 +41,6 @@ func createRegistryClient(
 	dic *di.Container) (registry.Client, error) {
 	bootstrapConfig := serviceConfig.GetBootstrap()
 
-	if *bootstrapConfig.Registry == (config.RegistryInfo{}) {
-		return nil, errors.New("Registry configuration is empty, missing common config? Use -cp or -cc flags for common config.")
-	}
-
 	var err error
 	var accessToken string
 	var getAccessToken registryTypes.GetAccessTokenCallback
@@ -73,7 +69,7 @@ func createRegistryClient(
 	}
 
 	if len(bootstrapConfig.Registry.Host) == 0 || bootstrapConfig.Registry.Port == 0 || len(bootstrapConfig.Registry.Type) == 0 {
-		return nil, errors.New("Registry config is incomplete, missing common config? Use -cp or -cc flags for common config.")
+		return nil, errors.New("Registry configuration is empty or incomplete, missing common config? Use -cp or -cc flags for common config.")
 	}
 
 	registryConfig := registryTypes.Config{


### PR DESCRIPTION
Gives a better error messages when the developer runs with hybrid mode but not including common config.

  Closes: #564

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
- git clone this PR
- you can use device-simple from device-sdk repo to test this out when running in hybrid mode and don't provide common config (i.e. no -cc flag in place when running it)
- in the device sdk, change the go-mod-bootstrap import to the local cloned go-mod-bootstrap in go.mod file
- run `make` first from the base root of device-sdk repo to compile the device-sdk together with the local go-mod-bootstrap
- change directory to device-simple under example/cmd:  `cd ./example/cmd/device-simple`
- run make again to compile the device simple app: `make` 
- run with `./device-simple` without any flags like -cc or -d
- you should expect to see some error message like 
```console
"Service.RequestTime found empty in bootstrap conifg, missing common config? Use -cp or -cc flags for common config"
```
- you could now edit the configuration.yml in the res folder of device-simple to add the missing entries or items to fix this error message to go further until you see the app is starting or running without bootstrapping failed message in the log 

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->