### PR TITLE
feat: initial implemention of openziti to go-mod-bootstrap

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -107,6 +107,7 @@ func RunAndReturnWaitGroup(
 		})
 	}
 
+	container.AdaptLogrusBasedLogging(dic)
 	translateInterruptToCancel(ctx, &wg, cancel)
 
 	envVars := environment.NewVariables(lc)

--- a/bootstrap/container/logging.go
+++ b/bootstrap/container/logging.go
@@ -15,7 +15,10 @@
 package container
 
 import (
+	"fmt"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	"github.com/sirupsen/logrus"
+	"io"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 )
@@ -31,4 +34,48 @@ func LoggingClientFrom(get di.Get) logger.LoggingClient {
 	}
 
 	return loggingClient
+}
+
+type LogrusAdaptor struct {
+	lc logger.LoggingClient
+}
+
+func (f *LogrusAdaptor) Format(entry *logrus.Entry) ([]byte, error) {
+	// Implement your custom formatting logic here
+	return []byte(fmt.Sprintf("[%s] %s\n", entry.Level, entry.Message)), nil
+}
+
+func (f *LogrusAdaptor) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+func (f *LogrusAdaptor) Fire(e *logrus.Entry) error {
+	switch e.Level {
+	case logrus.DebugLevel:
+		f.lc.Debug(e.Message)
+	case logrus.InfoLevel:
+		f.lc.Info(e.Message)
+	case logrus.WarnLevel:
+		f.lc.Warn(e.Message)
+	case logrus.ErrorLevel:
+		f.lc.Error(e.Message)
+	case logrus.FatalLevel:
+		f.lc.Error(e.Message)
+	case logrus.PanicLevel:
+		f.lc.Error(e.Message)
+	}
+
+	return nil
+}
+
+func AdaptLogrusBasedLogging(dic *di.Container) {
+	l := LoggingClientFrom(dic.Get)
+	// Create a new logger instance
+	hook := &LogrusAdaptor{
+		lc: l,
+	}
+	logrus.AddHook(hook)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		DisableColors: true,
+	})
+	logrus.SetOutput(io.Discard)
 }

--- a/bootstrap/container/zerotrust.go
+++ b/bootstrap/container/zerotrust.go
@@ -1,0 +1,89 @@
+package container
+
+import (
+	"context"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/config"
+	"github.com/edgexfoundry/go-mod-core-contracts/v3/clients/logger"
+	edge_apis "github.com/openziti/sdk-golang/edge-apis"
+	"github.com/openziti/sdk-golang/ziti"
+	"net"
+	"net/http"
+	"strings"
+)
+
+const (
+	OpenZitiControllerKey = "OpenZitiController"
+	ZeroTrustKey          = "zerotrust"
+)
+
+func AuthToOpenZiti(ozController, jwt string) ziti.Context {
+	openZitiRootUrl := "https://" + ozController
+	if !strings.Contains(openZitiRootUrl, "://") {
+		openZitiRootUrl = "https://" + ozController
+	}
+	caPool, caErr := ziti.GetControllerWellKnownCaPool(openZitiRootUrl)
+	if caErr != nil {
+		panic(caErr)
+	}
+
+	credentials := edge_apis.NewJwtCredentials(jwt)
+	credentials.CaPool = caPool
+
+	cfg := &ziti.Config{
+		ZtAPI:       openZitiRootUrl + "/edge/client/v1",
+		Credentials: credentials,
+	}
+	cfg.ConfigTypes = append(cfg.ConfigTypes, "all")
+
+	ctx, ctxErr := ziti.NewContext(cfg)
+	if ctxErr != nil {
+		panic(ctxErr)
+	}
+	if err := ctx.Authenticate(); err != nil {
+		panic(err)
+	}
+
+	return ctx
+}
+
+func isZeroTrust(secOpts map[string]string) bool {
+	return secOpts != nil && secOpts["Mode"] == ZeroTrustKey
+}
+
+func HttpTransportFromService(secretProvider interfaces.SecretProviderExt, serviceInfo config.ServiceInfo, lc logger.LoggingClient) http.RoundTripper {
+	roundTripper := http.DefaultTransport
+	if isZeroTrust(serviceInfo.SecurityOptions) {
+		lc.Infof("zero trust client detected for service: %s", serviceInfo.Host)
+		roundTripper = createZitifiedTransport(secretProvider, serviceInfo.SecurityOptions[OpenZitiControllerKey], lc)
+	}
+	return roundTripper
+}
+
+func HttpTransportFromClient(secretProvider interfaces.SecretProviderExt, clientInfo *config.ClientInfo, lc logger.LoggingClient) http.RoundTripper {
+	roundTripper := http.DefaultTransport
+	if isZeroTrust(clientInfo.SecurityOptions) {
+		lc.Infof("zero trust client detected for client: %s", clientInfo.Host)
+		roundTripper = createZitifiedTransport(secretProvider, clientInfo.SecurityOptions[OpenZitiControllerKey], lc)
+	}
+	return roundTripper
+}
+
+func createZitifiedTransport(secretProvider interfaces.SecretProviderExt, ozController string, lc logger.LoggingClient) http.RoundTripper {
+	jwt, errJwt := secretProvider.GetSelfJWT()
+	if errJwt != nil {
+		lc.Errorf("could not load jwt: %v", errJwt)
+		return nil
+	}
+	ctx := AuthToOpenZiti(ozController, jwt)
+
+	zitiContexts := ziti.NewSdkCollection()
+	zitiContexts.Add(ctx)
+
+	zitiTransport := http.DefaultTransport.(*http.Transport).Clone() // copy default transport
+	zitiTransport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialer := zitiContexts.NewDialerWithFallback(ctx /*&net.Dialer{}*/, nil)
+		return dialer.Dial(network, addr)
+	}
+	return zitiTransport
+}

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -58,12 +58,15 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 	lc := container.LoggingClientFrom(dic.Get)
 	config := container.ConfigurationFrom(dic.Get)
 	cb.registry = container.RegistryFrom(dic.Get)
-	jwtSecretProvider := secret.NewJWTSecretProvider(container.SecretProviderExtFrom(dic.Get))
 
 	if config.GetBootstrap().Clients != nil {
 		for serviceKey, serviceInfo := range *config.GetBootstrap().Clients {
 			var url string
 			var err error
+
+			sp := container.SecretProviderExtFrom(dic.Get)
+			jwtSecretProvider := secret.NewJWTSecretProvider(sp)
+			sp.SetHttpTransport(container.HttpTransportFromClient(sp, serviceInfo, lc))
 
 			if !serviceInfo.UseMessageBus {
 				url, err = cb.getClientUrl(serviceKey, serviceInfo.Url(), startupTimer, dic, lc)

--- a/bootstrap/interfaces/secret.go
+++ b/bootstrap/interfaces/secret.go
@@ -14,7 +14,10 @@
 
 package interfaces
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 // SecretProvider defines the contract for secret provider implementations that
 // allow secrets to be retrieved/stored from/to a services Secret Store and other secret related APIs.
@@ -68,4 +71,10 @@ type SecretProviderExt interface {
 
 	// IsJWTValid evaluates a given JWT and returns a true/false if the JWT is valid (i.e. belongs to us and current) or not
 	IsJWTValid(jwt string) (bool, error)
+
+	// HttpTransport
+	HttpTransport() http.RoundTripper
+
+	// HttpTransport
+	SetHttpTransport(rt http.RoundTripper)
 }

--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -20,6 +20,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v3/errors"
+	"net/http"
 	"strings"
 	"time"
 
@@ -244,4 +245,12 @@ func (p *InsecureProvider) GetSelfJWT() (string, error) {
 // IsJWTValid evaluates a given JWT and returns a true/false if the JWT is valid (i.e. belongs to us and current) or not
 func (p *InsecureProvider) IsJWTValid(jwt string) (bool, error) {
 	return true, nil
+}
+
+func (p *InsecureProvider) HttpTransport() http.RoundTripper {
+	return http.DefaultTransport
+}
+
+func (p *InsecureProvider) SetHttpTransport(_ http.RoundTripper) {
+	//empty on purpose
 }

--- a/bootstrap/secret/jwtprovider.go
+++ b/bootstrap/secret/jwtprovider.go
@@ -7,20 +7,29 @@ package secret
 
 import (
 	"fmt"
+	clientinterfaces "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces"
 	"net/http"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/interfaces"
-	clientInterfaces "github.com/edgexfoundry/go-mod-core-contracts/v3/clients/interfaces"
 )
 
 type jwtSecretProvider struct {
 	secretProvider interfaces.SecretProviderExt
+	roundTripper_a http.RoundTripper
 }
 
-func NewJWTSecretProvider(secretProvider interfaces.SecretProviderExt) clientInterfaces.AuthenticationInjector {
+func NewJWTSecretProvider(secretProvider interfaces.SecretProviderExt) clientinterfaces.AuthenticationInjector {
 	return &jwtSecretProvider{
 		secretProvider: secretProvider,
 	}
+}
+func NewJWTSecretProviderWithRT(secretProvider interfaces.SecretProviderExt, roundTripper_b http.RoundTripper) clientinterfaces.AuthenticationInjector {
+	j := &jwtSecretProvider{
+		secretProvider: secretProvider,
+		roundTripper_a: roundTripper_b,
+	}
+	secretProvider.SetHttpTransport(roundTripper_b)
+	return j
 }
 
 func (self *jwtSecretProvider) AddAuthenticationData(req *http.Request) error {
@@ -42,4 +51,8 @@ func (self *jwtSecretProvider) AddAuthenticationData(req *http.Request) error {
 	}
 
 	return nil
+}
+func (self *jwtSecretProvider) RoundTripper() http.RoundTripper {
+	// Do nothing to the request; used for unit tests
+	return self.secretProvider.HttpTransport()
 }

--- a/bootstrap/secret/secure.go
+++ b/bootstrap/secret/secure.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -65,6 +66,7 @@ type SecureProvider struct {
 	securityConsulTokenDuration        gometrics.Timer
 	securityRuntimeSecretTokenDuration gometrics.Timer
 	securityGetSecretDuration          gometrics.Timer
+	httpRoundTripper                   http.RoundTripper
 }
 
 // NewSecureProvider creates & initializes Provider instance for secure secrets.
@@ -476,4 +478,12 @@ func (p *SecureProvider) GetSelfJWT() (string, error) {
 // IsJWTValid evaluates a given JWT and returns a true/false if the JWT is valid (i.e. belongs to us and current) or not
 func (p *SecureProvider) IsJWTValid(jwt string) (bool, error) {
 	return p.secretClient.IsJWTValid(jwt)
+}
+
+func (p *SecureProvider) HttpTransport() http.RoundTripper {
+	return p.httpRoundTripper
+}
+
+func (p *SecureProvider) SetHttpTransport(rt http.RoundTripper) {
+	p.httpRoundTripper = rt
 }

--- a/config/types.go
+++ b/config/types.go
@@ -68,6 +68,9 @@ type ServiceInfo struct {
 	EnableNameFieldEscape bool
 	// CORSConfiguration defines the cross-origin resource sharing related settings
 	CORSConfiguration CORSConfigurationInfo
+	// SecurityOptions is a key/value map, used for configuring hosted services. Currently used for zero trust but
+	// could be for other options additional security related configuration
+	SecurityOptions map[string]string
 }
 
 // HealthCheck is a URL specifying a health check REST endpoint used by the Registry to determine if the
@@ -140,6 +143,9 @@ type ClientInfo struct {
 	Protocol string
 	// UseMessageBus indicates weather to use Messaging version of client
 	UseMessageBus bool
+	// SecurityOptions is a key/value map, used for configuring clients. Currently used for zero trust but
+	// could be for other options additional security related configuration
+	SecurityOptions map[string]string
 }
 
 func (c ClientInfo) Url() string {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,9 @@ require (
 	github.com/labstack/echo/v4 v4.11.4
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/openziti/sdk-golang v0.22.21
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
+	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -22,21 +24,43 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
+	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fatih/color v1.14.1 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
+	github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa // indirect
 	github.com/fxamacker/cbor/v2 v2.5.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/go-logr/logr v1.4.1 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
+	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/go-openapi/analysis v0.22.2 // indirect
+	github.com/go-openapi/errors v0.21.0 // indirect
+	github.com/go-openapi/jsonpointer v0.20.2 // indirect
+	github.com/go-openapi/jsonreference v0.20.4 // indirect
+	github.com/go-openapi/loads v0.21.5 // indirect
+	github.com/go-openapi/runtime v0.27.1 // indirect
+	github.com/go-openapi/spec v0.20.14 // indirect
+	github.com/go-openapi/strfmt v0.22.0 // indirect
+	github.com/go-openapi/swag v0.22.9 // indirect
+	github.com/go-openapi/validate v0.22.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.17.0 // indirect
 	github.com/go-redis/redis/v7 v7.3.0 // indirect
+	github.com/go-resty/resty/v2 v2.11.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
+	github.com/gorilla/schema v1.2.0 // indirect
+	github.com/gorilla/securecookie v1.1.1 // indirect
+	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/hashicorp/consul/api v1.27.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -45,35 +69,73 @@ require (
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/serf v0.10.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/kataras/go-events v0.0.3 // indirect
 	github.com/klauspost/compress v1.17.2 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
+	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/michaelquigley/pfxlog v0.6.10 // indirect
+	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/consulstructure v0.0.0-20190329231841-56fdc4d2da54 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/nats-io/nats.go v1.32.0 // indirect
 	github.com/nats-io/nkeys v0.4.7 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/openziti/channel/v2 v2.0.117 // indirect
+	github.com/openziti/edge-api v0.26.10 // indirect
+	github.com/openziti/foundation/v2 v2.0.36 // indirect
+	github.com/openziti/identity v1.0.69 // indirect
+	github.com/openziti/metrics v1.2.42 // indirect
+	github.com/openziti/secretstream v0.1.16 // indirect
+	github.com/openziti/transport/v2 v2.0.121 // indirect
+	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
+	github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
+	github.com/shirou/gopsutil/v3 v3.23.12 // indirect
+	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/speps/go-hashids v2.0.0+incompatible // indirect
 	github.com/spiffe/go-spiffe/v2 v2.1.7 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/tklauser/go-sysconf v0.3.12 // indirect
+	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	github.com/zeebo/errs v1.3.0 // indirect
+	github.com/zitadel/oidc/v2 v2.12.0 // indirect
+	go.mongodb.org/mongo-driver v1.13.1 // indirect
+	go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 // indirect
+	go.opentelemetry.io/otel v1.21.0 // indirect
+	go.opentelemetry.io/otel/metric v1.21.0 // indirect
+	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 // indirect
 	golang.org/x/mod v0.12.0 // indirect
-	golang.org/x/net v0.19.0 // indirect
-	golang.org/x/sync v0.4.0 // indirect
+	golang.org/x/net v0.20.0 // indirect
+	golang.org/x/oauth2 v0.16.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/term v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 // indirect
+	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b // indirect
 	google.golang.org/grpc v1.60.1 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
+	nhooyr.io/websocket v1.8.10 // indirect
 )


### PR DESCRIPTION
closes #650 

This is the initial PR to adopt OpenZiti into EdgexFoundry go-mod-bootstrap. Much of the functionality will be used in other repos. I've tried to be as thorough testing this as I could but I'm sure there will need to be work to fix/doc/etc. I wanted to get the code PR up as soon as possible to start getting feedback.

* Loggging - OpenZiti uses pfxlog which uses logrus. A hook is added to callback into EdgexFoundry's logger along with setting the default logger output to discard.
* auth_middleware is updated to allow connections from OpenZiti identities, defering authorization to OpenZiti
* SecretProvider now allows setting the HttpTransport to use. This is replaced by an OpenZiti implementation if zero trust is enabled, otherwise it's the default http transport
* any 'server' is now able to be removed from the IP-based underlay network entirely and able to be made available only via OpenZiti. This makes classic IP-based attacks impossible.
* SecurityOptions has been added to ServiceInfo and ClientInfo and is configured similarly to something like:
```
Service:
    SecurityOptions:
        Mode: "zerotrust"
        OpenZitiController: "openziti:1280"
        OpenZitiServiceName: "edgex.ui"
		
		
    core-command:
        Protocol: http
        Host: "core-command.edgex.ziti"
        Port: 80
        SecurityOptions:
            Mode: "zerotrust"
            OpenZitiController: "openziti:1280"
            OpenZitiServiceName: "edgex.core-command"
```


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
This is a sweeping change that crosses numerous repos. I don't know how to effectively answer this particular question and this one change is insufficient for testing. A larger, cross-cutting PR/effort is needed to put all the pieces together. I could use help with knowing how to satisfy this 

## New Dependency Instructions (If applicable)
* github.com/openziti/sdk-golang (and transitives)