### PR TITLE
fix: bootstrap ReadingClient for core-data

### DIFF
--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -79,6 +79,9 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 					container.EventClientName: func(get di.Get) interface{} {
 						return clients.NewEventClient(url, jwtSecretProvider, config.GetBootstrap().Service.EnableNameFieldEscape)
 					},
+					container.ReadingClientName: func(get di.Get) interface{} {
+						return clients.NewReadingClient(url, jwtSecretProvider, config.GetBootstrap().Service.EnableNameFieldEscape)
+					},
 				})
 			case common.CoreMetaDataServiceKey:
 				dic.Update(di.ServiceConstructorMap{

--- a/bootstrap/handlers/clients_test.go
+++ b/bootstrap/handlers/clients_test.go
@@ -231,6 +231,7 @@ func TestClientsBootstrapHandler(t *testing.T) {
 			}
 
 			eventClient := container.EventClientFrom(dic.Get)
+			readingClient := container.ReadingClientFrom(dic.Get)
 			commandClient := container.CommandClientFrom(dic.Get)
 			deviceServiceClient := container.DeviceServiceClientFrom(dic.Get)
 			deviceProfileClient := container.DeviceProfileClientFrom(dic.Get)
@@ -243,8 +244,10 @@ func TestClientsBootstrapHandler(t *testing.T) {
 
 			if test.CoreDataClientInfo != nil {
 				assert.NotNil(t, eventClient)
+				assert.NotNil(t, readingClient)
 			} else {
 				assert.Nil(t, eventClient)
+				assert.Nil(t, readingClient)
 			}
 
 			if test.CommandClientInfo != nil {


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [X] I am not introducing a new dependency (add notes below if you are)
- [X] I have added unit tests for the new feature or bug fix (if not, why?)
- [X] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Using the following branch of the minimal reproduction: https://github.com/jrtitus/edgex-app-reading-client-poc/tree/fix-bootstrap (referencing the commit in this PR)

The result is a non-nil `ReadingClient`:

```
level=INFO ts=2024-02-16T03:37:46.594768Z app=service-key source=service.go:587 msg="Service started in: 49.244084ms"
level=INFO ts=2024-02-16T03:37:46.601778Z app=service-key source=main.go:25 msg="Event Count: 575"
level=INFO ts=2024-02-16T03:37:46.60344Z app=service-key source=main.go:34 msg="Reading Count: 575"
```

Fixes https://github.com/edgexfoundry/go-mod-bootstrap/issues/663

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->