### PR TITLE
feat: allow clients to be zero trust

### DIFF
--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -18,7 +18,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"sync"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/edgexfoundry/go-mod-registry/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/v3/registry"
 
+	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -29,6 +29,7 @@ import (
 	"github.com/edgexfoundry/go-mod-registry/v3/pkg/types"
 	"github.com/edgexfoundry/go-mod-registry/v3/registry"
 
+	bscfg "github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v3/bootstrap/startup"
@@ -67,6 +68,9 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 
 			sp := container.SecretProviderExtFrom(dic.Get)
 			jwtSecretProvider := secret.NewJWTSecretProvider(sp)
+			if serviceInfo.SecurityOptions[bscfg.SecurityModeKey] == zerotrust.ConfigKey {
+				sp.EnableZeroTrust()
+			}
 			if rt, transpErr := zerotrust.HttpTransportFromClient(sp, serviceInfo, lc); transpErr != nil {
 				lc.Errorf("could not obtain an http client for use with zero trust provider: %v", transpErr)
 				return false

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -174,7 +174,7 @@ func (b *HttpServer) BootstrapHandler(
 		b.isRunning = true
 		listenMode := strings.ToLower(bootstrapConfig.Service.SecurityOptions[config.SecurityModeKey])
 		switch listenMode {
-		case zerotrust.ConfigKey:
+		case zerotrust.ZeroTrustMode:
 			secretProvider := container.SecretProviderExtFrom(dic.Get)
 			if secretProvider == nil {
 				err = errors.New("secret provider is nil. cannot proceed with zero trust configuration")

--- a/bootstrap/zerotrust/zerotrust.go
+++ b/bootstrap/zerotrust/zerotrust.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	OpenZitiControllerKey = "OpenZitiController"
-	ConfigKey             = "zerotrust"
+	ZeroTrustMode         = "zerotrust"
 )
 
 func AuthToOpenZiti(ozController, jwt string) (ziti.Context, error) {


### PR DESCRIPTION
following https://github.com/edgexfoundry/go-mod-bootstrap/issues/650 and https://github.com/edgexfoundry/go-mod-bootstrap/pull/659, when enabling app-services to be able to participate with the zero trust overlay it's necessary to mark the secret provider if the key zero trust mode is set

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>


