### PR TITLE
feat: Add service key to HTTP Server

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -60,8 +60,7 @@ const (
 	appServicesKey    = "app-services"
 	deviceServicesKey = "device-services"
 
-	SecurityModeKey        = "Mode"
-	OpenZitiServiceNameKey = "OpenZitiServiceName"
+	SecurityModeKey = "Mode"
 )
 
 var invalidRemoteHostsError = errors.New("-rsh/--remoteServiceHosts must contain 3 and only 3 comma seperated host names")

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -216,7 +216,7 @@ func (b *HttpServer) BootstrapHandler(
 				break
 			}
 
-			ozServiceName := "edgex." + b.serverKey
+			ozServiceName := zerotrust.OpenZitiServicePrefix + b.serverKey
 			lc.Infof("Using OpenZiti service name: %s", ozServiceName)
 			ln, listenErr := zitiCtx.Listen(ozServiceName)
 			if listenErr != nil {

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -216,13 +216,8 @@ func (b *HttpServer) BootstrapHandler(
 				break
 			}
 
-			ozServiceName := bootstrapConfig.Service.SecurityOptions[config.OpenZitiServiceNameKey]
-			if ozServiceName != "" {
-				lc.Infof("OpenZiti service name provided %s", ozServiceName)
-			} else {
-				ozServiceName = "edgex." + b.serverKey
-				lc.Infof("OpenZiti service name not provided. Using default, generated name: %s", ozServiceName)
-			}
+			ozServiceName := "edgex." + b.serverKey
+			lc.Infof("Using OpenZiti service name: %s", ozServiceName)
 			ln, listenErr := zitiCtx.Listen(ozServiceName)
 			if listenErr != nil {
 				err = fmt.Errorf("could not bind service " + ozServiceName + ": " + listenErr.Error())

--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -51,6 +51,7 @@ type HttpServer struct {
 	router           *echo.Echo
 	isRunning        bool
 	doListenAndServe bool
+	serverKey        string
 }
 
 type ZitiContext struct {
@@ -59,11 +60,12 @@ type ZitiContext struct {
 type OpenZitiIdentityKey struct{}
 
 // NewHttpServer is a factory method that returns an initialized HttpServer receiver struct.
-func NewHttpServer(router *echo.Echo, doListenAndServe bool) *HttpServer {
+func NewHttpServer(router *echo.Echo, doListenAndServe bool, serviceKey string) *HttpServer {
 	return &HttpServer{
 		router:           router,
 		isRunning:        false,
 		doListenAndServe: doListenAndServe,
+		serverKey:        serviceKey,
 	}
 }
 
@@ -214,10 +216,16 @@ func (b *HttpServer) BootstrapHandler(
 				break
 			}
 
-			serviceName := bootstrapConfig.Service.SecurityOptions[config.OpenZitiServiceNameKey]
-			ln, listenErr := zitiCtx.Listen(serviceName)
+			ozServiceName := bootstrapConfig.Service.SecurityOptions[config.OpenZitiServiceNameKey]
+			if ozServiceName != "" {
+				lc.Infof("OpenZiti service name provided %s", ozServiceName)
+			} else {
+				ozServiceName = "edgex." + b.serverKey
+				lc.Infof("OpenZiti service name not provided. Using default, generated name: %s", ozServiceName)
+			}
+			ln, listenErr := zitiCtx.Listen(ozServiceName)
 			if listenErr != nil {
-				err = fmt.Errorf("could not bind service " + serviceName + ": " + listenErr.Error())
+				err = fmt.Errorf("could not bind service " + ozServiceName + ": " + listenErr.Error())
 				break
 			}
 

--- a/bootstrap/zerotrust/zerotrust.go
+++ b/bootstrap/zerotrust/zerotrust.go
@@ -16,6 +16,7 @@ import (
 const (
 	OpenZitiControllerKey = "OpenZitiController"
 	ZeroTrustMode         = "zerotrust"
+	OpenZitiServicePrefix = "edgex."
 )
 
 func AuthToOpenZiti(ozController, jwt string) (ziti.Context, error) {


### PR DESCRIPTION
Adds the ability for a server to get the key passed in as a param. that key is then used to find/bind an OpenZiti service

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

