### PR TITLE
feat: CommandClient can encode MessageBus topic

### DIFF
--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -136,7 +136,11 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 					}
 
 					baseTopic := cfg.GetBootstrap().MessageBus.GetBaseTopicPrefix()
-					client = clientsMessaging.NewCommandClient(messageClient, baseTopic, timeout)
+					if cfg.GetBootstrap().Service.EnableNameFieldEscape {
+						client = clientsMessaging.NewCommandClientWithNameFieldEscape(messageClient, baseTopic, timeout)
+					} else {
+						client = clientsMessaging.NewCommandClient(messageClient, baseTopic, timeout)
+					}
 
 					lc.Infof("Using messaging for '%s' clients", serviceKey)
 				} else {

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.21
 require (
 	github.com/eclipse/paho.mqtt.golang v1.4.3
 	github.com/edgexfoundry/go-mod-configuration/v3 v3.2.0-dev.7
-	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.23
-	github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.25
+	github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.24
+	github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.26
 	github.com/edgexfoundry/go-mod-registry/v3 v3.2.0-dev.8
 	github.com/edgexfoundry/go-mod-secrets/v3 v3.2.0-dev.5
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -86,10 +86,10 @@ github.com/eclipse/paho.mqtt.golang v1.4.3 h1:2kwcUGn8seMUfWndX0hGbvH8r7crgcJguQ
 github.com/eclipse/paho.mqtt.golang v1.4.3/go.mod h1:CSYvoAlsMkhYOXh/oKyxa8EcBci6dVkLCbo5tTC1RIE=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.2.0-dev.7 h1:FTps28H9Phy/oVKJjAOdNFGVXRKXIqQo2rLQV8y5DVA=
 github.com/edgexfoundry/go-mod-configuration/v3 v3.2.0-dev.7/go.mod h1:WX+Cqr/+nXRKxNIcvekHdf5ubbTZX0D76Rj2T0FKmtA=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.23 h1:v9XI/lAZvLmrfOytnt4gexBsHrbesy49TIoqbmm8vFA=
-github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.23/go.mod h1:UR/LlHT6r+rbHKUUYJGNzW6tl4ywRENEnEkwf5QhI0s=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.25 h1:ZGYVAQdn9OI0i7LRt26Vw8897xosOBIePTYT02vL3JA=
-github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.25/go.mod h1:PXE87Ia/lH5vVQxLMEpzb4e2UTA1e3n8tZXSwRkf0uw=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.24 h1:FUZ+4iPgijhZ5TXNp7YF/44cfDGgn0voIma3suFSFCA=
+github.com/edgexfoundry/go-mod-core-contracts/v3 v3.2.0-dev.24/go.mod h1:UR/LlHT6r+rbHKUUYJGNzW6tl4ywRENEnEkwf5QhI0s=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.26 h1:Fkiki07fSxofusT6vV510CdoSwE0vy91xJTdPs8bO0Q=
+github.com/edgexfoundry/go-mod-messaging/v3 v3.2.0-dev.26/go.mod h1:PXE87Ia/lH5vVQxLMEpzb4e2UTA1e3n8tZXSwRkf0uw=
 github.com/edgexfoundry/go-mod-registry/v3 v3.2.0-dev.8 h1:taE3XDACmN9zwO0hrAdZEz1GGNOyUHSgspadC9Gz6GY=
 github.com/edgexfoundry/go-mod-registry/v3 v3.2.0-dev.8/go.mod h1:lW5yVe+SV/qGdEwDTM/qnt0Magfy4iXgGE6lxEsU0Fo=
 github.com/edgexfoundry/go-mod-secrets/v3 v3.2.0-dev.5 h1:RqNk0FOo5xu5Aqe0zq8ZpcELlKsbrsbJmIf/w+/1zsU=


### PR DESCRIPTION
Add enableNameFieldEscape parameter to CommandClient to enable MessageBus topic path encoding

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **not impact**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) **not impact**
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->