### PR TITLE
feat: Add new env to support -o flag

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -75,7 +75,6 @@ type Processor struct {
 	wg                 *sync.WaitGroup
 	configUpdated      UpdatedStream
 	dic                *di.Container
-	overwriteConfig    bool
 	providerHasConfig  bool
 	commonConfigClient configuration.Client
 	appConfigClient    configuration.Client
@@ -125,7 +124,6 @@ func (cp *Processor) Process(
 	serviceConfig interfaces.Configuration,
 	secretProvider interfaces.SecretProviderExt) error {
 
-	cp.overwriteConfig = cp.flags.OverwriteConfig()
 	configProviderUrl := cp.flags.ConfigProviderUrl()
 	remoteHosts := environment.GetRemoteServiceHosts(cp.lc, cp.flags.RemoteServiceHosts())
 
@@ -190,7 +188,7 @@ func (cp *Processor) Process(
 			return fmt.Errorf("failed check for Configuration Provider has private configiuration: %s", err.Error())
 		}
 
-		if cp.providerHasConfig && !cp.overwriteConfig {
+		if cp.providerHasConfig && !cp.overwriteConfig() {
 			privateServiceConfig, err = copyConfigurationStruct(serviceConfig)
 			if err != nil {
 				return err
@@ -236,7 +234,7 @@ func (cp *Processor) Process(
 	}
 
 	// Now load the private config from a local file if any of these conditions are true
-	if !useProvider || !cp.providerHasConfig || cp.overwriteConfig {
+	if !useProvider || !cp.providerHasConfig || cp.overwriteConfig() {
 		filePath := GetConfigFileLocation(cp.lc, cp.flags)
 		configMap, err := cp.loadConfigYamlFromFile(filePath)
 		if err != nil {
@@ -255,7 +253,7 @@ func (cp *Processor) Process(
 		}
 
 		if useProvider {
-			if err := privateConfigClient.PutConfigurationMap(configMap, cp.overwriteConfig); err != nil {
+			if err := privateConfigClient.PutConfigurationMap(configMap, cp.overwriteConfig()); err != nil {
 				return fmt.Errorf("could not push private configuration into Configuration Provider: %s", err.Error())
 			}
 
@@ -321,6 +319,10 @@ func (cp *Processor) Process(
 	}
 
 	return err
+}
+
+func (cp *Processor) overwriteConfig() bool {
+	return environment.OverwriteConfig() || cp.flags.OverwriteConfig()
 }
 
 func getLocalIP() string {
@@ -582,7 +584,7 @@ func (cp *Processor) LoadCustomConfigSection(updatableConfig interfaces.Updatabl
 				err.Error())
 		}
 
-		if exists && !cp.flags.OverwriteConfig() {
+		if exists && !cp.overwriteConfig() {
 			rawConfig, err := configClient.GetConfiguration(updatableConfig)
 			if err != nil {
 				return fmt.Errorf(
@@ -626,7 +628,7 @@ func (cp *Processor) LoadCustomConfigSection(updatableConfig interfaces.Updatabl
 			}
 
 			var overwriteMessage = ""
-			if exists && cp.flags.OverwriteConfig() {
+			if exists && cp.overwriteConfig() {
 				overwriteMessage = "(overwritten)"
 			}
 			cp.lc.Infof("Custom Config loaded from file and pushed to Configuration Provider %s", overwriteMessage)

--- a/bootstrap/environment/variables.go
+++ b/bootstrap/environment/variables.go
@@ -47,6 +47,7 @@ const (
 	envKeyConfigFile         = "EDGEX_CONFIG_FILE"
 	envKeyFileURITimeout     = "EDGEX_FILE_URI_TIMEOUT"
 	envKeyRemoteServiceHosts = "EDGEX_REMOTE_SERVICE_HOSTS"
+	envOverwriteConfig       = "EDGEX_OVERWRITE_CONFIG"
 
 	noConfigProviderValue = "none"
 
@@ -490,4 +491,19 @@ func GetRemoteServiceHosts(lc logger.LoggingClient, remoteHosts []string) []stri
 	logEnvironmentOverride(lc, "-rsh/--remoteServiceHosts", envKeyRemoteServiceHosts, envValue)
 
 	return strings.Split(envValue, ",")
+}
+
+// OverwriteConfig returns whether the local configuration should be pushed (overwrite) into the Configuration provider
+func OverwriteConfig() bool {
+	envValue := os.Getenv(envOverwriteConfig)
+	if len(envValue) == 0 {
+		return false
+	}
+
+	boolValue, err := strconv.ParseBool(envValue)
+	if err != nil {
+		return false
+	}
+
+	return boolValue
 }


### PR DESCRIPTION
Since the flag is hard to use for the container environment, create a new env EDGEX_OVERWRITE_CONFIG to provide the same feature support as -o/--overwrite flag.

Close #747

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
1. Start the EdgeX with the default configs and config provider.
2. Modify the docker-compose file with the environment variable `EDGEX_OVERWRITE_CONFIG: true` and set other environment variable to change the private or common config.
3. Check the config provider if the new change of the environment variable overwrite is pushed.