### PR TITLE
refactor: Replace old Scheduler service with cron Scheduler service

### DIFF
--- a/bootstrap/container/clients.go
+++ b/bootstrap/container/clients.go
@@ -131,30 +131,6 @@ func ProvisionWatcherClientFrom(get di.Get) interfaces.ProvisionWatcherClient {
 	return get(ProvisionWatcherClientName).(interfaces.ProvisionWatcherClient)
 }
 
-// IntervalClientName contains the name of the IntervalClient's implementation in the DIC.
-var IntervalClientName = di.TypeInstanceToName((*interfaces.IntervalClient)(nil))
-
-// IntervalClientFrom helper function queries the DIC and returns the IntervalClient's implementation.
-func IntervalClientFrom(get di.Get) interfaces.IntervalClient {
-	if get(IntervalClientName) == nil {
-		return nil
-	}
-
-	return get(IntervalClientName).(interfaces.IntervalClient)
-}
-
-// IntervalActionClientName contains the name of the IntervalActionClient's implementation in the DIC.
-var IntervalActionClientName = di.TypeInstanceToName((*interfaces.IntervalActionClient)(nil))
-
-// IntervalActionClientFrom helper function queries the DIC and returns the IntervalActionClient's implementation.
-func IntervalActionClientFrom(get di.Get) interfaces.IntervalActionClient {
-	if get(IntervalActionClientName) == nil {
-		return nil
-	}
-
-	return get(IntervalActionClientName).(interfaces.IntervalActionClient)
-}
-
 // DeviceServiceCallbackClientName contains the name of the DeviceServiceCallbackClient instance in the DIC.
 var DeviceServiceCallbackClientName = di.TypeInstanceToName((*interfaces.DeviceServiceCallbackClient)(nil))
 

--- a/bootstrap/handlers/clients.go
+++ b/bootstrap/handlers/clients.go
@@ -168,16 +168,6 @@ func (cb *ClientsBootstrap) BootstrapHandler(
 
 			case common.SupportSchedulerServiceKey:
 				dic.Update(di.ServiceConstructorMap{
-					container.IntervalClientName: func(get di.Get) interface{} {
-						return clients.NewIntervalClient(url, jwtSecretProvider, cfg.GetBootstrap().Service.EnableNameFieldEscape)
-					},
-					container.IntervalActionClientName: func(get di.Get) interface{} {
-						return clients.NewIntervalActionClient(url, jwtSecretProvider, cfg.GetBootstrap().Service.EnableNameFieldEscape)
-					},
-				})
-
-			case common.SupportCronSchedulerServiceKey:
-				dic.Update(di.ServiceConstructorMap{
 					container.ScheduleJobClientName: func(get di.Get) interface{} {
 						return clients.NewScheduleJobClient(url, jwtSecretProvider, cfg.GetBootstrap().Service.EnableNameFieldEscape)
 					},

--- a/bootstrap/handlers/clients_test.go
+++ b/bootstrap/handlers/clients_test.go
@@ -72,13 +72,7 @@ func TestClientsBootstrapHandler(t *testing.T) {
 		Protocol: "http",
 	}
 
-	subscriberClientInfo := config.ClientInfo{
-		Host:     "localhost",
-		Port:     59861,
-		Protocol: "http",
-	}
-
-	cronSchedulerClientInfo := config.ClientInfo{
+	schedulerClientInfo := config.ClientInfo{
 		Host:     "localhost",
 		Port:     59863,
 		Protocol: "http",
@@ -90,7 +84,6 @@ func TestClientsBootstrapHandler(t *testing.T) {
 	registryMock.On("GetServiceEndpoint", common.CoreCommandServiceKey).Return(types.ServiceEndpoint{}, nil)
 	registryMock.On("GetServiceEndpoint", common.SupportNotificationsServiceKey).Return(types.ServiceEndpoint{}, nil)
 	registryMock.On("GetServiceEndpoint", common.SupportSchedulerServiceKey).Return(types.ServiceEndpoint{}, nil)
-	registryMock.On("GetServiceEndpoint", common.SupportCronSchedulerServiceKey).Return(types.ServiceEndpoint{}, nil)
 
 	registryErrorMock := &registryMocks.Client{}
 	registryErrorMock.On("GetServiceEndpoint", common.CoreDataServiceKey).Return(types.ServiceEndpoint{}, errors.New("some error"))
@@ -98,92 +91,84 @@ func TestClientsBootstrapHandler(t *testing.T) {
 	startupTimer := startup.NewTimer(1, 1)
 
 	tests := []struct {
-		Name                    string
-		CoreDataClientInfo      *config.ClientInfo
-		CommandClientInfo       *config.ClientInfo
-		MetadataClientInfo      *config.ClientInfo
-		NotificationClientInfo  *config.ClientInfo
-		SchedulerClientInfo     *config.ClientInfo
-		CronSchedulerClientInfo *config.ClientInfo
-		Registry                registry.Client
-		ExpectedResult          bool
+		Name                   string
+		CoreDataClientInfo     *config.ClientInfo
+		CommandClientInfo      *config.ClientInfo
+		MetadataClientInfo     *config.ClientInfo
+		NotificationClientInfo *config.ClientInfo
+		SchedulerClientInfo    *config.ClientInfo
+		Registry               registry.Client
+		ExpectedResult         bool
 	}{
 		{
-			Name:                    "All ClientsBootstrap",
-			CoreDataClientInfo:      &coreDataClientInfo,
-			CommandClientInfo:       &commandHttpClientInfo,
-			MetadataClientInfo:      &metadataClientInfo,
-			NotificationClientInfo:  &notificationClientInfo,
-			SchedulerClientInfo:     &subscriberClientInfo,
-			CronSchedulerClientInfo: &cronSchedulerClientInfo,
-			Registry:                nil,
-			ExpectedResult:          true,
+			Name:                   "All ClientsBootstrap",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      &commandHttpClientInfo,
+			MetadataClientInfo:     &metadataClientInfo,
+			NotificationClientInfo: &notificationClientInfo,
+			SchedulerClientInfo:    &schedulerClientInfo,
+			Registry:               nil,
+			ExpectedResult:         true,
 		},
 		{
-			Name:                    "All ClientsBootstrap using registry",
-			CoreDataClientInfo:      &coreDataClientInfo,
-			CommandClientInfo:       &commandHttpClientInfo,
-			MetadataClientInfo:      &metadataClientInfo,
-			NotificationClientInfo:  &notificationClientInfo,
-			SchedulerClientInfo:     &subscriberClientInfo,
-			CronSchedulerClientInfo: &cronSchedulerClientInfo,
-			Registry:                registryMock,
-			ExpectedResult:          true,
+			Name:                   "All ClientsBootstrap using registry",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      &commandHttpClientInfo,
+			MetadataClientInfo:     &metadataClientInfo,
+			NotificationClientInfo: &notificationClientInfo,
+			SchedulerClientInfo:    &schedulerClientInfo,
+			Registry:               registryMock,
+			ExpectedResult:         true,
 		},
 		{
-			Name:                    "Core Data Client using registry fails",
-			CoreDataClientInfo:      &coreDataClientInfo,
-			CommandClientInfo:       nil,
-			MetadataClientInfo:      nil,
-			NotificationClientInfo:  nil,
-			SchedulerClientInfo:     nil,
-			CronSchedulerClientInfo: nil,
-			Registry:                registryErrorMock,
-			ExpectedResult:          false,
+			Name:                   "Core Data Client using registry fails",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     nil,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               registryErrorMock,
+			ExpectedResult:         false,
 		},
 		{
-			Name:                    "No ClientsBootstrap",
-			CoreDataClientInfo:      nil,
-			CommandClientInfo:       nil,
-			MetadataClientInfo:      nil,
-			NotificationClientInfo:  nil,
-			SchedulerClientInfo:     nil,
-			CronSchedulerClientInfo: nil,
-			Registry:                nil,
-			ExpectedResult:          true,
+			Name:                   "No ClientsBootstrap",
+			CoreDataClientInfo:     nil,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     nil,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               nil,
+			ExpectedResult:         true,
 		},
 		{
-			Name:                    "Only Core Data ClientsBootstrap",
-			CoreDataClientInfo:      &coreDataClientInfo,
-			CommandClientInfo:       nil,
-			MetadataClientInfo:      nil,
-			NotificationClientInfo:  nil,
-			SchedulerClientInfo:     nil,
-			CronSchedulerClientInfo: nil,
-			Registry:                nil,
-			ExpectedResult:          true,
+			Name:                   "Only Core Data ClientsBootstrap",
+			CoreDataClientInfo:     &coreDataClientInfo,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     nil,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               nil,
+			ExpectedResult:         true,
 		},
 		{
-			Name:                    "Only Metadata ClientsBootstrap",
-			CoreDataClientInfo:      nil,
-			CommandClientInfo:       nil,
-			MetadataClientInfo:      &metadataClientInfo,
-			NotificationClientInfo:  nil,
-			SchedulerClientInfo:     nil,
-			CronSchedulerClientInfo: nil,
-			Registry:                nil,
-			ExpectedResult:          true,
+			Name:                   "Only Metadata ClientsBootstrap",
+			CoreDataClientInfo:     nil,
+			CommandClientInfo:      nil,
+			MetadataClientInfo:     &metadataClientInfo,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               nil,
+			ExpectedResult:         true,
 		},
 		{
-			Name:                    "Only Messaging based Command ClientsBootstrap",
-			CoreDataClientInfo:      nil,
-			CommandClientInfo:       &commandMessagingClientInfo,
-			MetadataClientInfo:      nil,
-			NotificationClientInfo:  nil,
-			SchedulerClientInfo:     nil,
-			CronSchedulerClientInfo: nil,
-			Registry:                nil,
-			ExpectedResult:          true,
+			Name:                   "Only Messaging based Command ClientsBootstrap",
+			CoreDataClientInfo:     nil,
+			CommandClientInfo:      &commandMessagingClientInfo,
+			MetadataClientInfo:     nil,
+			NotificationClientInfo: nil,
+			SchedulerClientInfo:    nil,
+			Registry:               nil,
+			ExpectedResult:         true,
 		},
 	}
 
@@ -209,10 +194,6 @@ func TestClientsBootstrapHandler(t *testing.T) {
 
 			if test.SchedulerClientInfo != nil {
 				clients[common.SupportSchedulerServiceKey] = test.SchedulerClientInfo
-			}
-
-			if test.CronSchedulerClientInfo != nil {
-				clients[common.SupportCronSchedulerServiceKey] = test.CronSchedulerClientInfo
 			}
 
 			bootstrapConfig := config.BootstrapConfiguration{
@@ -267,8 +248,6 @@ func TestClientsBootstrapHandler(t *testing.T) {
 			provisionWatcherClient := container.ProvisionWatcherClientFrom(dic.Get)
 			notificationClient := container.NotificationClientFrom(dic.Get)
 			subscriptionClient := container.SubscriptionClientFrom(dic.Get)
-			intervalClient := container.IntervalClientFrom(dic.Get)
-			intervalActionClient := container.IntervalActionClientFrom(dic.Get)
 			scheduleJobClient := container.ScheduleJobClientFrom(dic.Get)
 			scheduleActionRecordClient := container.ScheduleActionRecordClientFrom(dic.Get)
 
@@ -307,14 +286,6 @@ func TestClientsBootstrapHandler(t *testing.T) {
 			}
 
 			if test.SchedulerClientInfo != nil {
-				assert.NotNil(t, intervalClient)
-				assert.NotNil(t, intervalActionClient)
-			} else {
-				assert.Nil(t, intervalClient)
-				assert.Nil(t, intervalActionClient)
-			}
-
-			if test.CronSchedulerClientInfo != nil {
 				assert.NotNil(t, scheduleJobClient)
 				assert.NotNil(t, scheduleActionRecordClient)
 			} else {


### PR DESCRIPTION
BREAKING CHANGE: the cron scheduler name and key changed

Replace the old Scheduler service with the new cron Scheduler service

fixes https://github.com/edgexfoundry/edgex-go/issues/5002

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->