### PR TITLE
fix: Execute the next handler function in auth_middleware

### DIFF
--- a/bootstrap/handlers/auth_middleware.go
+++ b/bootstrap/handlers/auth_middleware.go
@@ -27,6 +27,7 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/zerotrust"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
 	dtoCommon "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos/common"
+	edgexErr "github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/labstack/echo/v4"
@@ -50,7 +51,7 @@ import (
 // For typical usage, it is preferred to use AutoConfigAuthenticationFunc which
 // will automatically select between a real and a fake JWT validation handler.
 func AuthenticationHandlerFunc(dic *di.Container) echo.MiddlewareFunc {
-	return func(inner echo.HandlerFunc) echo.HandlerFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			lc := container.LoggingClientFrom(dic.Get)
 			secretProvider := container.SecretProviderExtFrom(dic.Get)
@@ -64,7 +65,7 @@ func AuthenticationHandlerFunc(dic *di.Container) echo.MiddlewareFunc {
 				if zitiCtx != nil {
 					if zitiEdgeConn, ok := zitiCtx.(edge.Conn); ok {
 						lc.Debugf("Authorizing incoming connection via OpenZiti for %s", zitiEdgeConn.SourceIdentifier())
-						return inner(c)
+						return next(c)
 					}
 					lc.Warn("context value for OpenZitiIdentityKey is not an edge.Conn")
 				}
@@ -87,15 +88,18 @@ func AuthenticationHandlerFunc(dic *di.Container) echo.MiddlewareFunc {
 					return echo.NewHTTPError(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
 				}
 
+				var err edgexErr.EdgeX
 				if issuer == openBaoIssuer {
-					return SecretStoreAuthenticationHandlerFunc(secretProvider, lc, token, c)
+					err = SecretStoreAuthenticationHandlerFunc(secretProvider, lc, token, c)
 				} else {
 					// Verify the JWT by invoking security-proxy-auth http client
-					err := headers.VerifyJWT(token, issuer, parsedToken.Method.Alg(), dic, r.Context())
-					if err != nil {
-						errResp := dtoCommon.NewBaseResponse("", err.Error(), err.Code())
-						return c.JSON(err.Code(), errResp)
-					}
+					err = headers.VerifyJWT(token, issuer, parsedToken.Method.Alg(), dic, r.Context())
+				}
+				if err != nil {
+					errResp := dtoCommon.NewBaseResponse("", err.Error(), err.Code())
+					return c.JSON(err.Code(), errResp)
+				} else {
+					return next(c)
 				}
 			}
 			err := fmt.Errorf("unable to parse JWT for call to '%s'; unauthorized", r.URL.Path)

--- a/bootstrap/handlers/auth_secretstore.go
+++ b/bootstrap/handlers/auth_secretstore.go
@@ -6,30 +6,26 @@
 package handlers
 
 import (
-	"net/http"
+	"fmt"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/interfaces"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 
 	"github.com/labstack/echo/v4"
 )
 
 // SecretStoreAuthenticationHandlerFunc verifies the JWT with a OpenBao-based JWT authentication check
-func SecretStoreAuthenticationHandlerFunc(secretProvider interfaces.SecretProviderExt, lc logger.LoggingClient, token string, c echo.Context) error {
+func SecretStoreAuthenticationHandlerFunc(secretProvider interfaces.SecretProviderExt, lc logger.LoggingClient, token string, c echo.Context) errors.EdgeX {
 	r := c.Request()
-	w := c.Response()
 
 	validToken, err := secretProvider.IsJWTValid(token)
 	if err != nil {
 		lc.Errorf("Error checking JWT validity by the secret provider: %v ", err)
-		// set Response.Committed to true in order to rewrite the status code
-		w.Committed = false
-		return echo.NewHTTPError(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+		return errors.NewCommonEdgeX(errors.KindServerError, "Error checking JWT validity by the secret provider", err)
 	} else if !validToken {
 		lc.Warnf("Request to '%s' UNAUTHORIZED", r.URL.Path)
-		// set Response.Committed to true in order to rewrite the status code
-		w.Committed = false
-		return echo.NewHTTPError(http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized))
+		return errors.NewCommonEdgeX(errors.KindUnauthorized, fmt.Sprintf("Request to '%s' UNAUTHORIZED", r.URL.Path), err)
 	}
 	lc.Debugf("Request to '%s' authorized", r.URL.Path)
 	return nil


### PR DESCRIPTION
Relates to #810. Execute the next handler function properly in auth_middleware.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->