### PR TITLE
fix: get updated configuration provider client for config changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.5.0
 	github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.12
 	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.22
-	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.11
+	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.12
 	github.com/edgexfoundry/go-mod-registry/v4 v4.0.0-dev.3
 	github.com/edgexfoundry/go-mod-secrets/v4 v4.0.0-dev.5
 	github.com/golang-jwt/jwt/v5 v5.2.1

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.12 h1:2P7kCcGMd5BX9NF
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.12/go.mod h1:sx5Zx+zAhmlFRNK2EblvOnCuUc099F2mHLWtZGfoWB8=
 github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.22 h1:XzDtbAmvp/v+DZlFoSgttnUQsIXGhlf+H8xgGxBClUA=
 github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.22/go.mod h1:D35HIMZkFFy82shKtPYaEL3Nn+ZNEjUjZI1RLn1j23E=
-github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.11 h1:JNhS2eIPNJI5Ie043pvxGlP+4SLXglGw+dHAqCguC48=
-github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.11/go.mod h1:BfIFNR+dinBvg3s2bHoIuRwpw5KwCbMtjtIu5T/0WwM=
+github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.12 h1:7Qh7cneaQweepVX80cgXQbrkdqqnWfRPj9cEIcsD+1I=
+github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.12/go.mod h1:BfIFNR+dinBvg3s2bHoIuRwpw5KwCbMtjtIu5T/0WwM=
 github.com/edgexfoundry/go-mod-registry/v4 v4.0.0-dev.3 h1:6tw6JqEJDOqo2lEgxjZ+scvsub5R20WGpInCuoxS6zE=
 github.com/edgexfoundry/go-mod-registry/v4 v4.0.0-dev.3/go.mod h1:QpZW5bWxsk0Leh1nvgojBZrpHA/B6dSw6LgT0zxh9hg=
 github.com/edgexfoundry/go-mod-secrets/v4 v4.0.0-dev.5 h1:PnbvMnedIlbqXsnUp2+i18BJ9e6CJ7GzwNA9vjPU3Jk=


### PR DESCRIPTION
correctly get configuration provider client to avoid nil panic

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->