### PR TITLE
fix: retrieve privateConfigClient from dic

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -116,12 +116,16 @@ func NewProcessorForCustomConfig(
 	ctx context.Context,
 	wg *sync.WaitGroup,
 	dic *di.Container) *Processor {
+
+	privateConfigClient := container.ConfigClientFrom(dic.Get)
+
 	return &Processor{
-		lc:    container.LoggingClientFrom(dic.Get),
-		flags: flags,
-		ctx:   ctx,
-		wg:    wg,
-		dic:   dic,
+		lc:                  container.LoggingClientFrom(dic.Get),
+		flags:               flags,
+		ctx:                 ctx,
+		wg:                  wg,
+		dic:                 dic,
+		privateConfigClient: privateConfigClient,
 	}
 }
 


### PR DESCRIPTION
close #840

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->