### PR TITLE
fix: avoid send on closed channel panic

### DIFF
--- a/bootstrap/config/config.go
+++ b/bootstrap/config/config.go
@@ -179,20 +179,6 @@ func (cp *Processor) Process(
 			serviceKey); err != nil {
 			return err
 		}
-
-		// listen for changes on Writable
-		cp.listenForPrivateChanges(serviceConfig, cp.privateConfigClient, utils.BuildBaseKey(configStem, serviceKey))
-		cp.lc.Infof("listening for private config changes")
-		cp.listenForCommonChanges(serviceConfig, cp.commonConfigClient, cp.privateConfigClient, utils.BuildBaseKey(configStem, common.CoreCommonConfigServiceKey, allServicesKey))
-		cp.lc.Infof("listening for all services common config changes")
-		if cp.appConfigClient != nil {
-			cp.listenForCommonChanges(serviceConfig, cp.appConfigClient, cp.privateConfigClient, utils.BuildBaseKey(configStem, common.CoreCommonConfigServiceKey, appServicesKey))
-			cp.lc.Infof("listening for application service common config changes")
-		}
-		if cp.deviceConfigClient != nil {
-			cp.listenForCommonChanges(serviceConfig, cp.deviceConfigClient, cp.privateConfigClient, utils.BuildBaseKey(configStem, common.CoreCommonConfigServiceKey, deviceServicesKey))
-			cp.lc.Infof("listening for device service common config changes")
-		}
 	} else {
 		// Now load common configuration from local file if not using config provider and -cc/--commonConfig flag is used.
 		// NOTE: Some security services don't use any common configuration and don't use the configuration provider.
@@ -330,6 +316,7 @@ func (cp *Processor) loadConfigByProvider(
 		cp.lc.Info("Private configuration has been pushed to into Configuration Provider with overrides applied")
 	}
 
+	// listen for changes on Writable
 	cp.listenForPrivateChanges(serviceConfig, cp.privateConfigClient, utils.BuildBaseKey(configStem, serviceKey))
 	cp.lc.Infof("listening for private config changes")
 	cp.listenForCommonChanges(serviceConfig, cp.commonConfigClient, cp.privateConfigClient, utils.BuildBaseKey(configStem, common.CoreCommonConfigServiceKey, allServicesKey))
@@ -684,10 +671,7 @@ func (cp *Processor) ListenForCustomConfigChanges(
 		defer cp.wg.Done()
 
 		errorStream := make(chan error)
-		defer close(errorStream)
-
 		updateStream := make(chan any)
-		defer close(updateStream)
 
 		go cp.privateConfigClient.WatchForChanges(updateStream, errorStream, configToWatch, sectionName, cp.getMessageClient)
 
@@ -797,10 +781,7 @@ func (cp *Processor) listenForPrivateChanges(serviceConfig interfaces.Configurat
 		defer cp.wg.Done()
 
 		errorStream := make(chan error)
-		defer close(errorStream)
-
 		updateStream := make(chan any)
-		defer close(updateStream)
 
 		go privateConfigClient.WatchForChanges(updateStream, errorStream, serviceConfig.EmptyWritablePtr(), writableKey, cp.getMessageClient)
 
@@ -859,10 +840,7 @@ func (cp *Processor) listenForCommonChanges(fullServiceConfig interfaces.Configu
 		var previousCommonWritable any
 
 		errorStream := make(chan error)
-		defer close(errorStream)
-
 		updateStream := make(chan any)
-		defer close(updateStream)
 
 		go commonConfigClient.WatchForChanges(updateStream, errorStream, fullServiceConfig.EmptyWritablePtr(), writableKey, cp.getMessageClient)
 


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/go-mod-bootstrap/issues/872

The send on close channel panic are occasionally observed when a service is terminated. The root cause is that go-mod-bootstrap implements listensForChanges by creating sender channel in the side of receiver, and close the sender channel in the side of receiver will cause the panic.

The simplest solution with least code refactor is to not defer close(updateStream) and defer close(errorStream) in listenForPrivateChanges, listenForCommonChanges, and ListenForCustomChanges since there is no need to close the channels.

Moreover, https://github.com/edgexfoundry/go-mod-bootstrap/pull/814 accidentally adds reduandant calls to listen for changes on Writable. As the `cp.loadConfigByProvider` will listen for changes on Writable at https://github.com/edgexfoundry/go-mod-bootstrap/pull/814/files#diff-5346c73553fe1e8350deb1a29ed066b1202c1ea35e57d206adbb6f359ed1d299R332-R343, there is no need to do it again at https://github.com/edgexfoundry/go-mod-bootstrap/pull/814/files#diff-5346c73553fe1e8350deb1a29ed066b1202c1ea35e57d206adbb6f359ed1d299R181-R192.

This fix also removes this redundant calls.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [ ] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->