### PR TITLE
feat: Integrate MessagingClient critical operation signaling into shutdown process

### DIFF
--- a/bootstrap/messaging/messaging.go
+++ b/bootstrap/messaging/messaging.go
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2021 Intel Corp.
+ * Copyright 2025 IOTech Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,12 +23,14 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/container"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/bootstrap/secret"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/config"
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
+	"github.com/edgexfoundry/go-mod-messaging/v4/messaging"
 )
 
 const (
@@ -156,4 +159,15 @@ func ValidateSecretData(authMode string, secretName string, secretData *SecretDa
 	}
 
 	return nil
+}
+
+func WaitForMsgClientCriticalOperations(lc logger.LoggingClient, mc messaging.MessageClient) {
+	mcExt, ok := mc.(messaging.MessageClientExt)
+	if ok {
+		if mcExt.WaitForCriticalOperations(10 * time.Second) {
+			lc.Debug("all critical operations completed")
+		} else {
+			lc.Warnf("timeout waiting for critical operations, continuing with shutdown")
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/eclipse/paho.mqtt.golang v1.5.0
 	github.com/edgexfoundry/go-mod-configuration/v4 v4.1.0-dev.12
 	github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.12
-	github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.13
+	github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.15
 	github.com/edgexfoundry/go-mod-registry/v4 v4.1.0-dev.4
 	github.com/edgexfoundry/go-mod-secrets/v4 v4.1.0-dev.4
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/edgexfoundry/go-mod-configuration/v4 v4.1.0-dev.12 h1:sW0dy9juPYPOwgw
 github.com/edgexfoundry/go-mod-configuration/v4 v4.1.0-dev.12/go.mod h1:8av7ex+XGeQHXQe/qyCdZ6g9AYWAYGRkkeFK0TKbiOQ=
 github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.12 h1:y5DmnfDWSzkil3n/mOM3geNlObQw59U75901R4s0a94=
 github.com/edgexfoundry/go-mod-core-contracts/v4 v4.1.0-dev.12/go.mod h1:amP1pD+VT+LkOJ5nryqYubgeBWBJTnqsq5sA/uKIyo0=
-github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.13 h1:rIG8wnB5YpaoT2sfXzrKoNFxSXuvLYbfM/iG6ONYB24=
-github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.13/go.mod h1:3G5kyVZFfn63u9st+D3reVTfifnERhWT12iX9lToOZM=
+github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.15 h1:TeuemI4+l8Z4mYXZ5MNi6VQWcXQqw2Nr+bsefJrWMdQ=
+github.com/edgexfoundry/go-mod-messaging/v4 v4.1.0-dev.15/go.mod h1:3G5kyVZFfn63u9st+D3reVTfifnERhWT12iX9lToOZM=
 github.com/edgexfoundry/go-mod-registry/v4 v4.1.0-dev.4 h1:xTQc2DpLTuaB2+sLuZzK3Mjg408e5Bchqe/sMhn0i30=
 github.com/edgexfoundry/go-mod-registry/v4 v4.1.0-dev.4/go.mod h1:FEhbilt+tiS6wnh82ltdNEYcQcV3fO8nCl3Vgl06QSI=
 github.com/edgexfoundry/go-mod-secrets/v4 v4.1.0-dev.4 h1:LFF4xEF7at3l0gI04h7VGNaiuGHUdnF93IPFzGkHHDA=


### PR DESCRIPTION
fix: #896 

This enables service to wait for MessagingClient critical operations to complete during graceful shutdown.

This depends on https://github.com/edgexfoundry/go-mod-messaging/pull/436

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

