### PR TITLE
fix: service running without config provider can still retrieve insecure secrets

### DIFF
--- a/bootstrap/secret/insecure.go
+++ b/bootstrap/secret/insecure.go
@@ -78,9 +78,14 @@ func (p *InsecureProvider) GetSecret(secretName string, keys ...string) (map[str
 	encodedSecretName := url.QueryEscape(secretName)
 
 	for _, insecureSecret := range insecureSecrets {
-		if insecureSecret.SecretName == encodedSecretName {
+		// for services running with the config provider, insecure secrets from core-keeper must be escaped to
+		// prevent conflicts with the '/' key delimiter, so compare with encodedSecretName to retrieve secrets
+		if insecureSecret.SecretName == encodedSecretName ||
+			// for services running without the config provider, insecure secrets stored in the config file are not
+			// necessarily escaped, so compare with secretName directly to retrieve secrets
+			insecureSecret.SecretName == secretName {
 			if len(keys) == 0 {
-				// If no keys are provided then all the keys associated with the specified secretName will be returned
+				// If no keys are provided, all the keys associated with the specified secretName will be returned
 				for k, v := range insecureSecret.SecretData {
 					results[k] = v
 				}


### PR DESCRIPTION
fixes https://github.com/edgexfoundry/go-mod-bootstrap/issues/918

Fix the regression caused by https://github.com/edgexfoundry/go-mod-bootstrap/pull/913, which assumes that all insecure secrets will be stored by invoking InsecureProvider.StoreSecret so the escape operation can take effect. However, this ignore the cases where services running without config provider, e.g. running service without specifying -cp. In this case, the insecure secrets will be directly retrieved from config file and are not escaped.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->