### PR TITLE
fix: Add Middleware to handle RequestTimeout

### DIFF
--- a/bootstrap/handlers/httpserver.go
+++ b/bootstrap/handlers/httpserver.go
@@ -36,7 +36,6 @@ import (
 	"github.com/edgexfoundry/go-mod-bootstrap/v4/di"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo/v4/middleware"
 )
 
 // HttpServer contains references to dependencies required by the http server implementation.
@@ -125,7 +124,7 @@ func (b *HttpServer) BootstrapHandler(
 
 	if timeout > 0 {
 		// Apply timeout middleware only when timeout is set
-		b.router.Use(middleware.ContextTimeout(timeout))
+		b.router.Use(RequestTimeoutMiddleware(timeout))
 	}
 
 	b.router.Use(RequestLimitMiddleware(bootstrapConfig.Service.MaxRequestSize, lc))
@@ -181,6 +180,37 @@ func (b *HttpServer) BootstrapHandler(
 	}()
 
 	return true
+}
+
+// RequestTimeoutMiddleware enforces a request timeout using http.TimeoutHandler.
+// The client receives a 503 immediately when the timeout is exceeded.
+//
+// Unlike echo's ContextTimeout which only sets a context deadline and requires the handler
+// to handle ctx.Done(), http.TimeoutHandler responds to the client immediately on timeout.
+func RequestTimeoutMiddleware(timeout time.Duration) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			h := http.TimeoutHandler(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					// - Replace the request so that c.Request().Context() carries the timeout context from TimeoutHandler, allowing downstream handlers to detect cancellation via ctx.Done().
+					// - Replace the writer with TimeoutHandler's mutex-protected writer, which safely discards concurrent writes after timeout.
+					// Both replacements preserve all original context data (route params, auth info, middleware values).
+					c.SetRequest(r)
+					c.SetResponse(echo.NewResponse(w, c.Echo()))
+					if err := next(c); err != nil {
+						// r.Context().Err() is nil means the request has not timed out, so it is safe to write the handler error response.
+						if r.Context().Err() == nil {
+							c.Echo().HTTPErrorHandler(err, c)
+						}
+					}
+				}),
+				timeout,
+				"request timeout",
+			)
+			h.ServeHTTP(c.Response().Writer, c.Request())
+			return nil
+		}
+	}
 }
 
 // RequestLimitMiddleware is a middleware function that limits the request body size to Service.MaxRequestSize in kilobytes

--- a/bootstrap/handlers/httpserver_test.go
+++ b/bootstrap/handlers/httpserver_test.go
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022-2023 IOTech Ltd
+// Copyright (C) 2022-2026 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/clients/logger"
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/common"
@@ -20,6 +21,53 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRequestTimeoutMiddleware(t *testing.T) {
+	tests := []struct {
+		name           string
+		timeout        time.Duration
+		handlerDelay   time.Duration
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "handler completes before timeout",
+			timeout:        100 * time.Millisecond,
+			handlerDelay:   0,
+			expectedStatus: http.StatusOK,
+			expectedBody:   "ok",
+		},
+		{
+			name:           "handler exceeds timeout",
+			timeout:        10 * time.Millisecond,
+			handlerDelay:   500 * time.Millisecond,
+			expectedStatus: http.StatusServiceUnavailable,
+			expectedBody:   "request timeout",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := echo.New()
+			e.Use(RequestTimeoutMiddleware(testCase.timeout))
+			e.GET("/", func(c echo.Context) error {
+				if testCase.handlerDelay > 0 {
+					time.Sleep(testCase.handlerDelay)
+				}
+				return c.String(http.StatusOK, "ok")
+			})
+
+			req, err := http.NewRequest(http.MethodGet, "/", nil)
+			require.NoError(t, err)
+
+			recorder := httptest.NewRecorder()
+			e.ServeHTTP(recorder, req)
+
+			assert.Equal(t, testCase.expectedStatus, recorder.Code)
+			assert.Equal(t, testCase.expectedBody, recorder.Body.String())
+		})
+	}
+}
 
 func TestRequestLimitMiddleware(t *testing.T) {
 	e := echo.New()


### PR DESCRIPTION
Since the middleware.ContextTimeout require to handle the context in each http handler, add Middleware to handle RequestTimeout.

Fix #952

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/go-mod-bootstrap/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)  not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->